### PR TITLE
Fix project update parameter mismatch

### DIFF
--- a/pulumi_lagoon/project.py
+++ b/pulumi_lagoon/project.py
@@ -124,10 +124,11 @@ class LagoonProjectProvider(dynamic.ResourceProvider):
 
         client = self._get_client()
 
-        # Prepare update data
-        update_args = {
-            "id": int(id),
-        }
+        # Store project ID for the API call (passed as positional argument)
+        project_id = int(id)
+
+        # Prepare update data (without id - passed separately to client method)
+        update_args = {}
 
         # Check which fields have changed and include them
         if new_inputs.get("git_url") != old_inputs.get("git_url"):
@@ -155,9 +156,9 @@ class LagoonProjectProvider(dynamic.ResourceProvider):
         if new_inputs.get("storage_calc") != old_inputs.get("storage_calc"):
             update_args["storageCalc"] = new_inputs.get("storage_calc")
 
-        # Only update if there are changes beyond the ID
-        if len(update_args) > 1:
-            result = client.update_project(**update_args)
+        # Only update if there are changes
+        if len(update_args) > 0:
+            result = client.update_project(project_id, **update_args)
 
             # Return updated outputs
             outs = {

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -113,6 +113,11 @@ class TestLagoonProjectProviderUpdate:
         mock_client.update_project.assert_called_once()
         assert result.outs["branches"] == "^(main|develop|staging)$"
 
+        # Verify correct calling convention: project_id as positional arg, not in kwargs
+        call_args, call_kwargs = mock_client.update_project.call_args
+        assert call_args == (1,), "Project ID should be first positional argument"
+        assert "id" not in call_kwargs, "ID should not be in kwargs"
+
     @patch("pulumi_lagoon.project.LagoonConfig")
     def test_update_project_no_changes(self, mock_config_class):
         """Test update with no actual changes returns inputs."""


### PR DESCRIPTION
## Summary
- Fix TypeError when updating Lagoon projects caused by parameter mismatch between provider and client
- The `update` method was passing project ID as keyword argument `id`, but `client.update_project()` expects `project_id` as positional argument
- Add test assertions to verify correct calling convention

Fixes #4

## Test plan
- [x] Run unit tests: `pytest tests/unit/test_project.py -v`
- [x] Run full test suite: `pytest tests/ -v`
- [ ] Manual testing with a real Lagoon instance (optional)