### PR TITLE
Fix Node.js 20 deprecation: upgrade upload/download-artifact actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: sdk/python/python
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: sdk/python/python/dist/
@@ -71,7 +71,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -96,7 +96,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -118,7 +118,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

Upgrades `actions/upload-artifact` and `actions/download-artifact` from v4 (Node.js 20) to the latest versions (Node.js 24 compatible) before the **June 2, 2026** forced migration deadline.

- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8` (3 occurrences)

Closes #42

## Test plan

- [ ] Verify the publish workflow runs cleanly on next release (no Node.js 20 deprecation warning)
- [ ] Confirm `upload-artifact@v7` and `download-artifact@v8` are compatible (both use GitHub's v2 artifact API)