### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -66,7 +66,7 @@ jobs:
         python-version: ['3.9', '3.11', '3.12']
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -18,10 +18,10 @@ jobs:
         go-version: ['1.26']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: provider/go.sum
@@ -38,10 +38,10 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache-dependency-path: provider/go.sum
@@ -53,10 +53,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache-dependency-path: provider/go.sum


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` → `actions/checkout@v6`
- `actions/setup-go@v5` → `actions/setup-go@v6`
- `actions/setup-python@v5` → `actions/setup-python@v6`

Node.js 20 is deprecated on GitHub Actions runners and will be forced to Node.js 24 by default starting June 2, 2026. These are the latest major versions of each action and natively support the Node.js 24 runtime.

## Test plan
- [x] CI passes on this PR (Go Tests workflow: build, vet, test jobs)