### PR TITLE
Copy root README into sdk/python/ before PyPI build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
           sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" pulumi_lagoon/pulumi-plugin.json
         working-directory: sdk/python
 
+      - name: Copy README for PyPI description
+        run: cp README.md sdk/python/README.md
+
       - name: Build package
         run: python -m build
         working-directory: sdk/python


### PR DESCRIPTION
## Summary

Adds a workflow step to copy the root `README.md` into `sdk/python/` before `python -m build` runs. This provides the long description that PyPI displays on the package page.

## Root Cause

`sdk/python/pyproject.toml` declares `readme = "README.md"`, but no `README.md` exists in `sdk/python/`. The build produces a wheel/sdist with no long description, so PyPI shows _"The author of this package has not provided a project description."_

## Change

```yaml
- name: Copy README for PyPI description
  run: cp README.md sdk/python/README.md
```

Inserted before the `python -m build` step in the `build` job. This copies from the repo root at build time — no committed duplicate file needed.

## Dependencies

This PR is based on **PR #55** (which moves `sdk/python/python/` → `sdk/python/`). It should be merged after #55.

## Test Plan

- [ ] Trigger a test publish via `workflow_dispatch` with `test_pypi: true` after #55 merges
- [ ] Verify https://test.pypi.org/project/pulumi-lagoon/ shows the project description

Closes #51