### PR TITLE
Update release notes and docs for v0.2.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ The provider is available on PyPI (`pip install pulumi-lagoon`), npm (`@tag1cons
 - Go-based native provider using `pulumi-go-provider` v1.3.0 (`infer` package)
 - Generated SDKs for Python, TypeScript, and Go from a single schema
 - Published to PyPI (`pulumi-lagoon`), npm (`@tag1consulting/pulumi-lagoon`), and Go module
-- 198 unit tests; comprehensive resource CRUD lifecycle
+- 512 unit tests; comprehensive resource CRUD lifecycle
 
 ## Development Environment
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,13 +20,17 @@ group = Group("my-team",
 
 ## Bug Fixes
 
+- **Group ID type**: Lagoon returns UUIDs (strings) for group IDs, not integers. Fixed `Group.ID` and `GroupState.LagoonID` types and updated the schema accordingly.
+- **Group delete idempotency**: `DeleteGroup` now correctly handles "Group not found" errors so that deleting an already-removed group succeeds instead of erroring.
+- **Group parentGroup queries reverted**: The `parentGroup` field is not exposed on Lagoon's `GroupInterface` type. Reverted query additions that caused `Cannot query field "parentGroup"` errors. The `Read` handler preserves `parentGroupName` from Pulumi state instead.
+- **Task fallback predicate tightened**: `isFieldNotFoundOrLegacyError` now only triggers legacy API fallback for `advancedTasksForEnvironment` field errors, preventing false-positive fallbacks on unrelated API errors.
 - **SDK path fix**: Corrected doubled SDK directory paths (`sdk/python/python/` → `sdk/python/`, `sdk/nodejs/nodejs/` → `sdk/nodejs/`) caused by `pulumi package gen-sdk`
 - **PyPI README**: Fixed missing project description on PyPI by copying the root README into the Python SDK before building
 - **npm badge**: Fixed broken npm version badge that used the non-existent `badge.npmjs.com` service
 
 ## Improvements
 
-- **Test coverage**: Expanded from ~40% to 87.4% (418 tests, up from ~200)
+- **Test coverage**: Expanded from ~40% to 87.4% (512 tests, up from ~200)
 - **CI**: Added `test-build.yml` workflow to validate the Python SDK builds correctly on every PR
 
 ## Installation


### PR DESCRIPTION
## Summary

- Add bug fixes discovered during live testing to RELEASE_NOTES.md (Group UUID type, delete idempotency, parentGroup revert, task fallback)
- Update test count in CLAUDE.md (198 -> 512)

These doc updates should land before tagging v0.2.2.