### PR TITLE
Fix utilities.ts package.json path for installed packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,6 +443,9 @@ go-sdk-nodejs: go-build
 	@for f in index.ts provider.ts utilities.ts tsconfig.json; do \
 		if [ -f "$(SDK_TMP)/nodejs/$$f" ]; then cp "$(SDK_TMP)/nodejs/$$f" "sdk/nodejs/$$f"; fi; \
 	done
+	# Fix generated path: utilities.ts uses require('./package.json') but compiles to bin/
+	# where package.json is one level up, so patch it to require('../package.json').
+	sed -i "s|require('./package.json')|require('../package.json')|g" sdk/nodejs/utilities.ts
 	cp LICENSE sdk/nodejs/LICENSE
 	rm -rf $(SDK_TMP)
 

--- a/sdk/nodejs/utilities.ts
+++ b/sdk/nodejs/utilities.ts
@@ -42,7 +42,7 @@ export function getEnvNumber(...vars: string[]): number | undefined {
 }
 
 export function getVersion(): string {
-    let version = require('./package.json').version;
+    let version = require('../package.json').version;
     // Node allows for the version to be prefixed by a "v", while semver doesn't.
     // If there is a v, strip it off.
     if (version.indexOf('v') === 0) {


### PR DESCRIPTION
## Summary

- `sdk/nodejs/utilities.ts`: changes `require('./package.json')` to `require('../package.json')`
- `Makefile`: adds a `sed` fixup in the `go-sdk-nodejs` target so future SDK regenerations automatically get the correct path

## Root cause

`bin/utilities.js` (compiled from `utilities.ts`) calls `require('./package.json')`. Node.js resolves `./` relative to the calling module's directory, so at runtime this looks for `bin/package.json` — a file that doesn't exist. The `package.json` lives one level up at the package root, so the path must be `require('../package.json')`.

This was a pre-existing bug in the Pulumi-generated code, exposed by the `test-install-nodejs` smoke test added in #70, which caused the `publish-npm` job in the v0.2.4 release run to be blocked (npm was never published for v0.2.4).

## Why the Makefile fix is needed

The `go-sdk-nodejs` target copies a freshly generated `utilities.ts` from the Pulumi SDK generator on every SDK regeneration. Without the `sed` fixup, the wrong path would be restored on each `make go-sdk-nodejs` run.

## Test plan

- [ ] `test-install-nodejs` passes in CI
- [ ] After merge: roll v0.2.5 to get `@tag1consulting/pulumi-lagoon` first published to npmjs.com (required before PR#71 OIDC setup)