### PR TITLE
Release v0.2.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ clean-all: clean
 # Go Provider (Native)
 #==============================================================================
 
-PROVIDER_VERSION ?= 0.2.4
+PROVIDER_VERSION ?= 0.2.5
 PROVIDER_BIN     := provider/bin/pulumi-resource-lagoon
 GO_BIN           ?= $(if $(GOPATH),$(GOPATH)/bin,$(HOME)/go/bin)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+# Release v0.2.5 (2026-03-26)
+
+Patch release fixing the Node.js SDK so `@tag1consulting/pulumi-lagoon` can be installed and required correctly.
+
+## Bug Fixes
+
+- **Node.js SDK `require` path**: `bin/utilities.js` called `require('./package.json')` which resolves to `bin/package.json` — a file that doesn't exist after `npm install`. Fixed to `require('../package.json')` so it correctly finds the package root. This caused the `test-install-nodejs` smoke test to fail in v0.2.4, blocking npm publishing entirely.
+- **Makefile `go-sdk-nodejs`**: Added `sed` fixup so future SDK regenerations automatically patch the generated `utilities.ts` path, preventing regression.
+
+## Installation
+
+```bash
+pip install pulumi-lagoon==0.2.5
+npm install @tag1consulting/pulumi-lagoon@0.2.5
+go get github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.2.5
+```
+
+---
+
 # Release v0.2.4 (2026-03-26)
 
 Maintenance release fixing pkg.go.dev license display, PyPI badge accuracy, README version text, and adding automated npm publishing for the TypeScript SDK.

--- a/provider/cmd/pulumi-resource-lagoon/main.go
+++ b/provider/cmd/pulumi-resource-lagoon/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is set at build time via ldflags.
-var Version = "0.2.4"
+var Version = "0.2.5"
 
 func main() {
 	provider, err := lagoon.NewProvider(Version)

--- a/provider/schema.json
+++ b/provider/schema.json
@@ -1,7 +1,7 @@
 {
   "name": "lagoon",
   "displayName": "Lagoon",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Manage Lagoon hosting platform resources as infrastructure-as-code.",
   "keywords": [
     "lagoon",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tag1consulting/pulumi-lagoon",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "keywords": [
         "lagoon",
         "hosting",
@@ -27,7 +27,7 @@
     "pulumi": {
         "resource": true,
         "name": "lagoon",
-        "version": "0.2.4",
+        "version": "0.2.5",
         "server": "https://github.com/tag1consulting/pulumi-lagoon-provider/releases/download/v${VERSION}"
     }
 }

--- a/sdk/python/pulumi_lagoon/pulumi-plugin.json
+++ b/sdk/python/pulumi_lagoon/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "lagoon",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "server": "https://github.com/tag1consulting/pulumi-lagoon-provider/releases/download/v${VERSION}"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["lagoon", "hosting", "kubernetes", "pulumi"]
   readme = "README.md"
   requires-python = ">=3.9"
-  version = "0.2.4"
+  version = "0.2.5"
   license = "Apache-2.0"
   [project.urls]
     Homepage = "https://github.com/tag1consulting/pulumi-lagoon-provider"


### PR DESCRIPTION
## Summary

Patch release fixing the Node.js SDK `require` path so `@tag1consulting/pulumi-lagoon` installs and loads correctly. This is what was blocking npm from ever being published in v0.2.4.

- `sdk/nodejs/utilities.ts`: `require('./package.json')` → `require('../package.json')`
- `Makefile`: `sed` fixup in `go-sdk-nodejs` so regeneration doesn't regress the path
- Version bumped to 0.2.5 across all manifests

## Test plan

- [x] `make release-prep VERSION=0.2.5` passes (512 tests)
- [x] `sed` fixup applied correctly during SDK regeneration (`utilities.ts` has `require('../package.json')`)
- [x] `test-install-nodejs` passes in CI on this PR
- [ ] After merge: tag `v0.2.5` + `sdk/go/lagoon/v0.2.5`, create GitHub release
- [ ] `@tag1consulting/pulumi-lagoon@0.2.5` appears on npmjs.com