### PR TITLE
Fix PyPI badge in README.pypi.md: switch from badge.fury.io to shields.io

### DIFF
--- a/sdk/python/README.pypi.md
+++ b/sdk/python/README.pypi.md
@@ -1,6 +1,6 @@
 # Pulumi Lagoon Provider — Python SDK
 
-[![PyPI version](https://badge.fury.io/py/pulumi-lagoon.svg)](https://pypi.org/project/pulumi-lagoon/)
+[![PyPI version](https://img.shields.io/pypi/v/pulumi-lagoon.svg)](https://pypi.org/project/pulumi-lagoon/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tag1consulting/pulumi-lagoon-provider/blob/main/LICENSE)
 
 A Pulumi provider for managing [Lagoon](https://www.lagoon.sh/) resources as infrastructure-as-code.


### PR DESCRIPTION
## Summary

`sdk/python/README.pypi.md` (the README displayed on the PyPI package page) was still using `badge.fury.io` for the PyPI version badge. This CDN has aggressive caching that showed a stale version (0.2.2) even after publishing 0.2.5.

Switches to `https://img.shields.io/pypi/v/pulumi-lagoon.svg` which is a dynamic badge that always reflects the current version on PyPI at render time — no manual updates needed on each release.

This is the same fix already applied to the root `README.md` in #70.