### PR TITLE
Release v0.2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,7 +401,7 @@ clean-all: clean
 # Go Provider (Native)
 #==============================================================================
 
-PROVIDER_VERSION ?= 0.2.5
+PROVIDER_VERSION ?= 0.2.6
 PROVIDER_BIN     := provider/bin/pulumi-resource-lagoon
 GO_BIN           ?= $(if $(GOPATH),$(GOPATH)/bin,$(HOME)/go/bin)
 
@@ -480,6 +480,7 @@ release-prep: check-release-version
 	sed -i 's/var Version = .*/var Version = "$(VERSION)"/' provider/cmd/pulumi-resource-lagoon/main.go
 	sed -i 's/^PROVIDER_VERSION ?= .*/PROVIDER_VERSION ?= $(VERSION)/' Makefile
 	sed -i 's/"version": ".*"/"version": "$(VERSION)"/' provider/schema.json
+	sed -i 's/\*\*Status\*\*: v[0-9]*\.[0-9]*\.[0-9]*/\*\*Status\*\*: v$(VERSION)/' README.md
 	$(MAKE) PROVIDER_VERSION=$(VERSION) go-build go-sdk-python go-sdk-nodejs go-sdk-go
 	sed -i 's/^  version = .*/  version = "$(VERSION)"/' sdk/python/pyproject.toml
 	jq --indent 4 --arg v "$(VERSION)" '.version = $$v | .pulumi.version = $$v' sdk/nodejs/package.json > sdk/nodejs/package.json.tmp && mv sdk/nodejs/package.json.tmp sdk/nodejs/package.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Pulumi provider for managing [Lagoon](https://www.lagoon.sh/) resources as inf
 
 This provider enables you to manage Lagoon hosting platform resources (projects, environments, variables, deploy targets, notifications, tasks, etc.) using Pulumi, with native SDKs for Python, TypeScript/JavaScript, and Go.
 
-**Status**: v0.2.4 — Native Go Provider
+**Status**: v0.2.6 — Native Go Provider
 
 ## Supported Resources
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+# Release v0.2.6 (2026-03-26)
+
+Maintenance release switching npm publishing to OIDC trusted publishing, upgrading the Node.js toolchain, and fixing the PyPI badge in the Python SDK README.
+
+## Improvements
+
+- **npm OIDC publishing**: Replaced token-based npm publishing (`NPM_TOKEN` secret) with npm's OIDC trusted publishing (GA since July 2025), matching the existing PyPI pattern. No secrets required — GitHub Actions exchanges an OIDC token directly with npmjs.com. Adds `--provenance` for SLSA attestation and a verified publisher badge on npmjs.com.
+- **Node.js toolchain upgrade**: Dropped Node.js 18 (EOL April 2025) and 20 (maintenance EOL); build and publish now use Node.js 24 (Active LTS); test matrix is `['22', '24']`.
+- **`npm ci` in CI**: Switched from `npm install` to `npm ci` in all CI jobs for reproducible, lock-file-pinned installs.
+- **PyPI badge**: Fixed stale `badge.fury.io` badge in `sdk/python/README.pypi.md`; now uses `shields.io` dynamic badge matching the root README.
+
+## Installation
+
+```bash
+pip install pulumi-lagoon==0.2.6
+npm install @tag1consulting/pulumi-lagoon@0.2.6
+go get github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.2.6
+```
+
+---
+
 # Release v0.2.5 (2026-03-26)
 
 Patch release fixing the Node.js SDK so `@tag1consulting/pulumi-lagoon` can be installed and required correctly.

--- a/provider/cmd/pulumi-resource-lagoon/main.go
+++ b/provider/cmd/pulumi-resource-lagoon/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is set at build time via ldflags.
-var Version = "0.2.5"
+var Version = "0.2.6"
 
 func main() {
 	provider, err := lagoon.NewProvider(Version)

--- a/provider/schema.json
+++ b/provider/schema.json
@@ -1,7 +1,7 @@
 {
   "name": "lagoon",
   "displayName": "Lagoon",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Manage Lagoon hosting platform resources as infrastructure-as-code.",
   "keywords": [
     "lagoon",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tag1consulting/pulumi-lagoon",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "keywords": [
         "lagoon",
         "hosting",
@@ -27,7 +27,7 @@
     "pulumi": {
         "resource": true,
         "name": "lagoon",
-        "version": "0.2.5",
+        "version": "0.2.6",
         "server": "https://github.com/tag1consulting/pulumi-lagoon-provider/releases/download/v${VERSION}"
     }
 }

--- a/sdk/python/pulumi_lagoon/pulumi-plugin.json
+++ b/sdk/python/pulumi_lagoon/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "lagoon",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "server": "https://github.com/tag1consulting/pulumi-lagoon-provider/releases/download/v${VERSION}"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["lagoon", "hosting", "kubernetes", "pulumi"]
   readme = "README.md"
   requires-python = ">=3.9"
-  version = "0.2.5"
+  version = "0.2.6"
   license = "Apache-2.0"
   [project.urls]
     Homepage = "https://github.com/tag1consulting/pulumi-lagoon-provider"


### PR DESCRIPTION
## Summary

- npm OIDC trusted publishing (replaces `NPM_TOKEN` token-based auth)
- Node.js 24 (Active LTS); test matrix `['22', '24']`; `npm ci` in all CI jobs
- PyPI badge fixed in `sdk/python/README.pypi.md` (shields.io)
- `README.md` status line updated to v0.2.6
- `release-prep` now automatically updates the `README.md` status line on each release

## Test plan

- [x] `make release-prep VERSION=0.2.6` passes (512 tests)
- [x] README.md status updated to v0.2.6
- [x] CI passes on this PR
- [ ] After merge: tag `v0.2.6` + `sdk/go/lagoon/v0.2.6`, create GitHub release
- [ ] Verify npm publish uses OIDC (no `NPM_TOKEN` required)