### PR TITLE
Add Go module proxy warm-up to release process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,3 +238,46 @@ jobs:
             npm publish --access public --provenance
           fi
         working-directory: sdk/nodejs
+
+  warm-go-proxy:
+    name: Warm Go module proxy
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Extract version from release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+][a-zA-Z0-9._-]+)?$'; then
+            echo "ERROR: tag '${GITHUB_REF_NAME}' does not look like a semver version" >&2
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Warm Go module proxy
+        env:
+          GO_MODULE: github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon
+          GO_PROXY: https://proxy.golang.org
+        run: |
+          echo "Warming proxy for ${GO_MODULE}@v${VERSION}"
+          for endpoint in .info .mod .zip; do
+            url="${GO_PROXY}/${GO_MODULE}/@v/v${VERSION}${endpoint}"
+            echo -n "  GET ${url} ... "
+            success=false
+            for attempt in 1 2 3; do
+              code=$(curl -s -o /dev/null -w '%{http_code}' "${url}")
+              if [ "${code}" = "200" ]; then
+                echo "200 OK"
+                success=true
+                break
+              fi
+              echo -n "(${code}, retry ${attempt}/3) "
+              sleep 10
+            done
+            if [ "${success}" != "true" ]; then
+              echo "FAILED (last status: ${code})"
+              echo "::error::Go module proxy did not return 200 for ${url}"
+              echo "Ensure the tag sdk/go/lagoon/v${VERSION} was pushed before creating the release."
+              exit 1
+            fi
+          done
+          echo "Go module proxy warm-up complete."

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
         multi-cluster-deploy multi-cluster-verify multi-cluster-port-forwards multi-cluster-port-forwards-all \
         multi-cluster-test-api multi-cluster-test-ui multi-cluster-info \
         clean clean-all venv \
-        go-build go-test go-vet go-schema go-sdk-clean go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-all go-install check-release-version release-prep
+        go-build go-test go-vet go-schema go-sdk-clean go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-all go-install check-release-version release-prep go-proxy-warmup
 
 # Variables
 VENV_DIR := venv
@@ -491,6 +491,39 @@ release-prep: check-release-version
 	@echo "Remaining steps:"
 	@echo "  1. Update RELEASE_NOTES.md"
 	@echo "  2. Commit, push, and open PR to main"
-	@echo "  3. After merge: git tag -a v$(VERSION) && git push origin v$(VERSION)"
-	@echo "  4. Create GitHub release (triggers PyPI publish)"
-	@echo "  5. Tag Go module: git tag -a sdk/go/lagoon/v$(VERSION) v$(VERSION)^{} && git push origin sdk/go/lagoon/v$(VERSION)"
+	@echo "  3. After merge: git tag v$(VERSION) && git push origin v$(VERSION)"
+	@echo "  4. Tag Go module: git tag sdk/go/lagoon/v$(VERSION) v$(VERSION)^{} && git push origin sdk/go/lagoon/v$(VERSION)"
+	@echo "  5. Create GitHub release (triggers publish.yml: PyPI, npm, Go proxy warm-up)"
+	@echo "  6. Verify: make go-proxy-warmup VERSION=$(VERSION)  (or check CI)"
+
+# Warm the Go module proxy so the SDK is immediately available via go get and
+# appears on pkg.go.dev.  The sdk/go/lagoon/vVERSION tag must already exist
+# on the remote before running this.
+# Usage: make go-proxy-warmup VERSION=0.3.0
+GO_MODULE := github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon
+GO_PROXY  := https://proxy.golang.org
+
+go-proxy-warmup: check-release-version
+	@echo "=== Warming Go module proxy for $(GO_MODULE)@v$(VERSION) ==="
+	@for endpoint in .info .mod .zip; do \
+		url="$(GO_PROXY)/$(GO_MODULE)/@v/v$(VERSION)$$endpoint"; \
+		echo -n "  GET $$url ... "; \
+		status=0; \
+		for attempt in 1 2 3; do \
+			code=$$(curl -s -o /dev/null -w '%{http_code}' "$$url"); \
+			if [ "$$code" = "200" ]; then \
+				echo "200 OK"; \
+				status=1; \
+				break; \
+			fi; \
+			echo -n "($$code, retry $$attempt/3) "; \
+			sleep 10; \
+		done; \
+		if [ "$$status" = "0" ]; then \
+			echo "FAILED"; \
+			echo "ERROR: proxy returned non-200 for $$url" >&2; \
+			echo "Ensure the tag sdk/go/lagoon/v$(VERSION) has been pushed." >&2; \
+			exit 1; \
+		fi; \
+	done
+	@echo "=== Go module proxy warm-up complete ==="

--- a/memory-bank/release-process.md
+++ b/memory-bank/release-process.md
@@ -38,30 +38,26 @@ After `release-prep` completes, still do manually:
 ### 1. Tag the release on main
 
 ```bash
-git tag -a v0.X.Y -m "Release v0.X.Y"
+git tag v0.X.Y
 git push origin v0.X.Y
 ```
 
 ### 2. Create the Go module subdirectory tag
 
-**IMPORTANT**: The Go module proxy requires a subdirectory-prefixed tag for nested
-modules. Without this, `go get` cannot resolve the SDK at a tagged version and
-falls back to pseudo-versions.
+**IMPORTANT**: Push this tag **before** creating the GitHub release so the
+`warm-go-proxy` CI job finds it when the release event fires.
+
+The Go module proxy requires a subdirectory-prefixed tag for nested modules.
+Without this, `go get` cannot resolve the SDK at a tagged version and falls
+back to pseudo-versions.
 
 ```bash
-git tag -a "sdk/go/lagoon/v0.X.Y" "v0.X.Y^{}" -m "Go SDK v0.X.Y"
+git tag "sdk/go/lagoon/v0.X.Y" "v0.X.Y^{}"
 git push origin "sdk/go/lagoon/v0.X.Y"
 ```
 
 Note: Use `v0.X.Y^{}` (not `v0.X.Y`) to dereference the annotated tag and point
 to the underlying commit. Otherwise Git creates a nested tag-of-a-tag.
-
-Verify it resolves on the Go proxy:
-
-```bash
-GOPROXY=https://proxy.golang.org go list -m \
-  github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.X.Y
-```
 
 ### 3. Create the GitHub Release
 
@@ -70,17 +66,16 @@ gh release create v0.X.Y --title "v0.X.Y" --notes-file RELEASE_NOTES_EXCERPT.md
 ```
 
 This triggers the `publish.yml` workflow which:
-- Builds the Python SDK wheel
-- Tests installation on Python 3.9, 3.11, 3.12
-- Publishes to PyPI (`pulumi-lagoon`)
-- Builds and publishes the TypeScript SDK to npm (`@tag1consulting/pulumi-lagoon`) — requires `NPM_TOKEN` secret in a GitHub `npm` environment
+- Builds the Python SDK wheel; tests on Python 3.9, 3.11, 3.12; publishes to PyPI via OIDC
+- Builds the TypeScript SDK; tests on Node.js 22, 24; publishes to npm via OIDC
+- Warms the Go module proxy (`warm-go-proxy` job)
 
 ### 4. Post-Release Verification
 
 - [ ] PyPI: `pip install pulumi-lagoon==0.X.Y` works
 - [ ] npm: `npm view @tag1consulting/pulumi-lagoon version` shows `0.X.Y`
-- [ ] Go: `GOPROXY=https://proxy.golang.org go list -m github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.X.Y` resolves
-- [ ] pkg.go.dev: `https://pkg.go.dev/github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.X.Y` shows documentation (may take ~5 min)
+- [ ] Go proxy: `make go-proxy-warmup VERSION=0.X.Y` returns 200 OK for all endpoints (automated via CI, run manually as fallback)
+- [ ] pkg.go.dev: `https://pkg.go.dev/github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.X.Y` shows documentation (may take up to an hour after proxy warm-up)
 - [ ] GitHub release page shows correct notes
 
 ## Known Gotchas
@@ -130,13 +125,20 @@ cp LICENSE sdk/go/lagoon/LICENSE
 ```
 The `--exclude='LICENSE'` prevents rsync from deleting the file during regeneration.
 
-### npm publishing requires GitHub environment setup
-The `publish-npm` job in `publish.yml` requires:
+### npm publishing requires GitHub environment setup (OIDC)
+The `publish-npm` job in `publish.yml` uses OIDC trusted publishing (no `NPM_TOKEN`
+secret). It requires:
 1. A GitHub environment named `npm` in the repository settings
-2. An `NPM_TOKEN` secret in that environment (npm automation token for `@tag1consulting`)
+2. npm trusted publishing configured at npmjs.com for `@tag1consulting/pulumi-lagoon`
+   (Granular Access Token → OIDC, linked to this repository and environment)
 3. The first publish uses `--access public` (required for scoped packages)
 
-Without this setup, the publish step will fail silently on release.
+### Go proxy warm-up timing
+The `warm-go-proxy` CI job fires when the GitHub release is published. It assumes
+the `sdk/go/lagoon/v0.X.Y` tag already exists at that point. **Always push both
+tags before creating the GitHub release** — if the Go tag is missing, the job
+fails with a clear error message. Run `make go-proxy-warmup VERSION=0.X.Y`
+manually after pushing the tag to recover.
 
 ### Token expiry during live testing
 Keycloak OAuth tokens expire in 5 minutes. For live testing, use JWT admin tokens


### PR DESCRIPTION
## Summary

- Adds a `warm-go-proxy` job to `publish.yml` that automatically hits the Go module proxy (`.info`, `.mod`, `.zip` endpoints) on each GitHub release, ensuring pkg.go.dev indexes the new SDK version immediately
- Adds `make go-proxy-warmup VERSION=X.Y.Z` as a manual fallback target
- Reorders the release checklist so the `sdk/go/lagoon/vX.Y.Z` tag is pushed **before** creating the GitHub release (required for the CI job to find the tag when the release event fires)
- Fixes a stale reference to `NPM_TOKEN` in `memory-bank/release-process.md` (npm now uses OIDC since v0.2.6)

Fixes #78.

## Test plan

- [x] `make go-proxy-warmup VERSION=0.2.6` runs locally and returns 200 OK for all three endpoints
- [ ] On next release, verify `warm-go-proxy` job passes in Actions UI
- [ ] pkg.go.dev shows Apache-2.0 license and documentation within an hour of next release