### PR TITLE
Fix release-prep sed: anchor README status pattern to start of line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ release-prep: check-release-version
 	sed -i 's/var Version = .*/var Version = "$(VERSION)"/' provider/cmd/pulumi-resource-lagoon/main.go
 	sed -i 's/^PROVIDER_VERSION ?= .*/PROVIDER_VERSION ?= $(VERSION)/' Makefile
 	sed -i 's/"version": ".*"/"version": "$(VERSION)"/' provider/schema.json
-	sed -i 's/\*\*Status\*\*: v[0-9]*\.[0-9]*\.[0-9]*/\*\*Status\*\*: v$(VERSION)/' README.md
+	sed -i 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' README.md
 	$(MAKE) PROVIDER_VERSION=$(VERSION) go-build go-sdk-python go-sdk-nodejs go-sdk-go
 	sed -i 's/^  version = .*/  version = "$(VERSION)"/' sdk/python/pyproject.toml
 	jq --indent 4 --arg v "$(VERSION)" '.version = $$v | .pulumi.version = $$v' sdk/nodejs/package.json > sdk/nodejs/package.json.tmp && mv sdk/nodejs/package.json.tmp sdk/nodejs/package.json


### PR DESCRIPTION
Fixes #76.

## Change

```diff
- sed -i 's/\*\*Status\*\*: v[0-9]*\.[0-9]*\.[0-9]*/\*\*Status\*\*: v$(VERSION)/' README.md
+ sed -i 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' README.md
```

Two improvements:
1. Added `^` anchor — ensures only a line *starting with* `**Status**: vX.Y.Z` is rewritten, preventing silent corruption of any future table cells, inline code, or sentences that contain that pattern
2. Changed `[0-9]*` to `[0-9]\+` — requires at least one digit per version component, avoiding a match on a bare `**Status**: v` with empty components

GNU sed (`\+`) is used in CI (ubuntu-latest) and standard Linux. No behavior change on the current README, which has exactly one match at line 15 (start of line).