### PR TITLE
Refactor: extract venv bootstrap into ensure-venv helper target

### DIFF
--- a/examples/simple-project/Makefile
+++ b/examples/simple-project/Makefile
@@ -15,7 +15,7 @@
 #   make clean         - Kill port-forwards and clean up
 #   make install       - Install provider in development mode
 
-.PHONY: help setup preview up destroy refresh output clean port-forwards token check install
+.PHONY: help setup preview up destroy refresh output clean port-forwards token check ensure-venv install
 
 PYTHON := python3
 
@@ -94,12 +94,15 @@ clean:
 	@pkill -f "port-forward.*lagoon-core" 2>/dev/null || true
 	@echo "Done."
 
-# Install the Go SDK Python package into a local virtualenv
-install:
-	@echo "Installing Lagoon provider SDK..."
+# Ensure a Python virtual environment exists
+ensure-venv:
 	@if [ ! -d "venv" ]; then \
 		echo "Creating virtual environment..."; \
 		$(PYTHON) -m venv venv; \
 	fi
+
+# Install the Go SDK Python package into a local virtualenv
+install: ensure-venv
+	@echo "Installing Lagoon provider SDK..."
 	@./venv/bin/pip install -q -r requirements.txt
 	@echo "SDK installed. Activate with: source venv/bin/activate"


### PR DESCRIPTION
## Summary

- Extracts the virtual environment creation guard from the `install` recipe body into a dedicated `ensure-venv` target
- `install` now depends on `ensure-venv`, keeping its body short (3 lines, within checkmake's default `maxbodylength`)
- `ensure-venv` is available as a reusable prerequisite for any future target that needs a venv before running
- No behavior change

Closes #83

## Test plan

- [x] `make -C examples/simple-project install` creates venv and installs deps (first run)
- [x] `make -C examples/simple-project install` (second run) skips venv creation, only pip installs
- [x] `make -C examples/simple-project ensure-venv` works standalone
- [x] Root `make example-setup` still delegates correctly to `install` (verified via `make -n` dry run — live Lagoon not available)