### PR TITLE
Fix single-cluster virtualenv path mismatch

### DIFF
--- a/examples/single-cluster/Makefile
+++ b/examples/single-cluster/Makefile
@@ -24,8 +24,8 @@ help:
 	@echo "  make fix-migration-lock - Fix API migration lock (CrashLoopBackOff)"
 	@echo "  make show-access-info   - Show browser access info and credentials"
 
-# Use shared venv from repository root
-VENV := ../../venv
+# Local virtual environment (must match Pulumi.yaml virtualenv setting)
+VENV := venv
 PYTHON := $(VENV)/bin/python
 PULUMI := pulumi
 
@@ -36,7 +36,7 @@ setup:
 	@if [ ! -d "$(VENV)" ]; then \
 		echo "Creating virtual environment..."; \
 		python3 -m venv $(VENV); \
-		$(VENV)/bin/pip install -r ../multi-cluster/requirements.txt; \
+		$(VENV)/bin/pip install -r requirements.txt; \
 	fi
 	@$(PULUMI) stack init dev 2>/dev/null || echo "Stack already exists"
 

--- a/examples/single-cluster/README.md
+++ b/examples/single-cluster/README.md
@@ -26,11 +26,8 @@ This example deploys a complete Lagoon stack to a single Kind cluster. It's a si
 # From repository root
 cd examples/single-cluster
 
-# Initialize Pulumi stack
-pulumi stack init dev
-
-# Deploy
-pulumi up
+# Setup and deploy (creates venv, initializes stack, deploys)
+make deploy
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary

- Fix `Makefile` to create venv locally (`venv/`) instead of at `../../venv` (repo root), matching `Pulumi.yaml`'s `virtualenv: venv` setting
- Fix `Makefile` to install from local `requirements.txt` instead of `../multi-cluster/requirements.txt`
- Update README Quick Start to use `make deploy` (handles venv setup, stack init, and deploy in one step)

Without this fix, `pulumi up` fails immediately for new developers following the README Quick Start because Pulumi expects `./venv` but it doesn't exist.

## Test plan

- [ ] `cd examples/single-cluster && make deploy` creates local `venv/` and succeeds
- [ ] `cd examples/single-cluster && pulumi up` works after `make setup`

Fixes #86