### PR TITLE
Fix setup-complete.sh cluster name default; add PyJWT to single-cluster

### DIFF
--- a/examples/single-cluster/requirements.txt
+++ b/examples/single-cluster/requirements.txt
@@ -12,5 +12,8 @@ pulumi-tls>=5.0.0,<6.0.0
 # For YAML processing (Kind config generation)
 pyyaml>=6.0.0
 
+# For JWT token generation (used by scripts/run-pulumi.sh)
+PyJWT>=2.0.0
+
 # Lagoon provider (native Go SDK)
 -e ../../sdk/python/

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -7,9 +7,9 @@
 # Configuration via environment variables:
 #
 # Cluster Configuration:
-#   KUBE_CONTEXT         - Kubernetes context (default: kind-lagoon-test)
+#   KUBE_CONTEXT         - Kubernetes context (default: kind-lagoon)
 #   LAGOON_NAMESPACE     - Namespace for Lagoon core (default: lagoon)
-#   KIND_CLUSTER_NAME    - Kind cluster name for docker inspect (default: lagoon-test)
+#   KIND_CLUSTER_NAME    - Kind cluster name for docker inspect (default: lagoon)
 #
 # Service Names (vary between single-cluster and multi-cluster):
 #   KEYCLOAK_SVC         - Keycloak service name (default: lagoon-core-keycloak)

--- a/scripts/setup-complete.sh
+++ b/scripts/setup-complete.sh
@@ -34,7 +34,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Configuration
-CLUSTER_NAME="${CLUSTER_NAME:-lagoon-test}"
+CLUSTER_NAME="${CLUSTER_NAME:-lagoon}"
 VENV_DIR="${VENV_DIR:-$ROOT_DIR/venv}"
 TEST_CLUSTER_DIR="$ROOT_DIR/test-cluster"
 EXAMPLE_DIR="$ROOT_DIR/examples/simple-project"
@@ -92,7 +92,7 @@ Options:
   --help            Show this help message
 
 Environment Variables:
-  CLUSTER_NAME      Kind cluster name (default: lagoon-test)
+  CLUSTER_NAME      Kind cluster name (default: lagoon)
   VENV_DIR          Python virtual environment path (default: ./venv)
 
 Prerequisites:


### PR DESCRIPTION
## Summary

- Fix `scripts/setup-complete.sh` to default `CLUSTER_NAME` to `lagoon` (was `lagoon-test`), matching `scripts/common.sh` and the Makefile
- Fix stale comments in `scripts/common.sh` that documented the old `lagoon-test` default
- Add `PyJWT>=2.0.0` to `examples/single-cluster/requirements.txt` (required by `scripts/run-pulumi.sh` for JWT token generation)

Running `setup-complete.sh` without setting `CLUSTER_NAME` previously created a cluster named `lagoon-test`, causing all subsequent `make` targets and scripts (which expect `lagoon`) to fail with cluster/context not found errors.

## Test plan

- [ ] `./scripts/setup-complete.sh` creates Kind cluster named `lagoon` (not `lagoon-test`)
- [ ] `make check-health` finds the cluster after `setup-complete.sh` runs
- [ ] `scripts/run-pulumi.sh` can import `jwt` when using single-cluster venv

Fixes #87