### PR TITLE
Update Go 1.22→1.26 and Python 3.8→3.9 version references

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -135,9 +135,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version: '1.26'
 
       - name: Build and vet Go SDK
         run: go build ./... && go vet ./...

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ lagoon get project --project my-project
 
 ### Prerequisites
 
-- Go 1.22+
+- Go 1.26+
 - Pulumi CLI
 - Docker, Kind, kubectl (for local test clusters)
 

--- a/examples/multi-cluster/README.md
+++ b/examples/multi-cluster/README.md
@@ -10,7 +10,7 @@ This example deploys a complete Lagoon infrastructure across two Kind clusters:
 - Kind (Kubernetes in Docker)
 - kubectl
 - Pulumi CLI
-- Python 3.8+
+- Python 3.9+
 
 ## Quick Start
 

--- a/examples/simple-project/README.md
+++ b/examples/simple-project/README.md
@@ -12,7 +12,7 @@ Uses the `pulumi_lagoon` provider to create:
 ## Prerequisites
 
 - A running Lagoon instance (see `examples/single-cluster/` or `examples/multi-cluster/`)
-- Python 3.8+ with the provider installed: `pip install pulumi-lagoon`
+- Python 3.9+ with the provider installed: `pip install pulumi-lagoon`
 - `curl` and `jq` for the helper scripts
 
 ## Quick Start

--- a/examples/single-cluster/README.md
+++ b/examples/single-cluster/README.md
@@ -17,7 +17,7 @@ This example deploys a complete Lagoon stack to a single Kind cluster. It's a si
 - Kind (`brew install kind` or see [kind.sigs.k8s.io](https://kind.sigs.k8s.io/))
 - kubectl
 - Helm
-- Python 3.8+
+- Python 3.9+
 - Pulumi CLI
 
 ## Quick Start

--- a/scripts/setup-complete.sh
+++ b/scripts/setup-complete.sh
@@ -23,7 +23,7 @@
 #   - kind CLI installed (https://kind.sigs.k8s.io/)
 #   - kubectl installed
 #   - pulumi CLI installed
-#   - Python 3.8+
+#   - Python 3.9+
 #
 # Total time: ~15-20 minutes for full setup
 
@@ -100,7 +100,7 @@ Prerequisites:
   - kind CLI installed (https://kind.sigs.k8s.io/)
   - kubectl installed
   - pulumi CLI installed
-  - Python 3.8+
+  - Python 3.9+
 
 Examples:
   # Full setup from scratch


### PR DESCRIPTION
## Summary

- `README.md`: `Go 1.22+` → `Go 1.26+` (matches `provider/go.mod`)
- `.github/workflows/test-build.yml` `test-go-sdk` job: `setup-go@v5` → `setup-go@v6`, `go-version: '1.22'` → `'1.26'`
- `examples/single-cluster/README.md`: `Python 3.8+` → `Python 3.9+`
- `examples/multi-cluster/README.md`: `Python 3.8+` → `Python 3.9+`
- `examples/simple-project/README.md`: `Python 3.8+` → `Python 3.9+`
- `scripts/setup-complete.sh`: `Python 3.8+` → `Python 3.9+` (two occurrences)

The v0.2.0 release notes explicitly dropped Python 3.8 support. `provider/go.mod` and `test-go.yml` already use Go 1.26 correctly; this PR brings the remaining references into alignment.

## Test plan

- [x] CI `test-go-sdk` job passes using Go 1.26

Fixes #89