### PR TITLE
Release v0.2.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This provider allows you to declaratively manage Lagoon hosting platform resourc
 
 ## Project Status
 
-**Status**: v0.2.6 Released (Native Go Provider)
+**Status**: v0.2.7 Released (Native Go Provider)
 
 The provider is available on PyPI (`pip install pulumi-lagoon`), npm (`@tag1consulting/pulumi-lagoon`), and Go (`github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon`). v0.2.x ships the native Go provider with generated multi-language SDKs, replacing the Python dynamic provider.
 

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ clean-all: clean
 # Go Provider (Native)
 #==============================================================================
 
-PROVIDER_VERSION ?= 0.2.6
+PROVIDER_VERSION ?= 0.2.7
 PROVIDER_BIN     := provider/bin/pulumi-resource-lagoon
 GO_BIN           ?= $(if $(GOPATH),$(GOPATH)/bin,$(HOME)/go/bin)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Pulumi provider for managing [Lagoon](https://www.lagoon.sh/) resources as inf
 
 This provider enables you to manage Lagoon hosting platform resources (projects, environments, variables, deploy targets, notifications, tasks, etc.) using Pulumi, with native SDKs for Python, TypeScript/JavaScript, and Go.
 
-**Status**: v0.2.6 — Native Go Provider
+**Status**: v0.2.7 — Native Go Provider
 
 ## Supported Resources
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+# Release v0.2.7 (2026-03-27)
+
+Maintenance release removing the legacy Python dynamic provider, expanding CI test coverage, and fixing documentation accuracy across the single-cluster and multi-cluster examples.
+
+## Breaking Changes
+
+None. The legacy Python dynamic provider code was already superseded by the native Go provider in v0.2.0 and is now fully removed. Users on v0.2.x are unaffected.
+
+## Improvements
+
+- **Remove legacy Python dynamic provider** (#82, closes #77): Deleted the old `provider/` Python source, legacy Makefile targets, and all references to the dynamic provider. The native Go provider has been the authoritative implementation since v0.2.0; this removes dead code and reduces confusion for new contributors.
+- **Expanded CI test coverage** (#80): Added smoke tests for Node.js pack+install, Go SDK vet, and all 12 Python SDK imports. Tests now cover all three SDK languages end-to-end in CI.
+- **Go module proxy warm-up** (#79): Added `warm-go-proxy` CI job that fires on GitHub release creation, ensuring the Go module proxy is primed for `go get` immediately after release.
+- **Makefile `ensure-venv` helper** (#84): Extracted virtualenv bootstrap into a reusable `ensure-venv` target to reduce duplication across install-related targets.
+- **Release tooling**: Fixed `release-prep` sed anchor to prevent Makefile self-modification (#81); added `CLAUDE.md` and `RELEASE_NOTES.md` to version bump automation (#93).
+
+## Bug Fixes
+
+- **Go SDK LICENSE for pkg.go.dev** (#85): Automated `LICENSE` copy to `sdk/go/lagoon/` during SDK regeneration so pkg.go.dev can detect Apache 2.0 and display documentation.
+- **Multi-cluster docs** (#97, #101): Fixed incorrect Keycloak secret name; corrected description of scripts (not symlinks); added `config/` README; added jq to documented prerequisites (#91).
+- **Single-cluster setup** (#95, #96): Fixed virtualenv path mismatch in Makefile; fixed `setup-complete.sh` cluster name default; added PyJWT dependency; added provider build prerequisite step to example READMEs.
+- **Version reference updates** (#89, #98): Updated Go 1.22→1.26 and Python 3.8→3.9 version references throughout documentation.
+
+## Documentation
+
+- `memory-bank/release-process.md`: Added Claude Code automation section documenting the `/release` skill and `release-validator` agent.
+
+## Installation
+
+```bash
+pip install pulumi-lagoon==0.2.7
+npm install @tag1consulting/pulumi-lagoon@0.2.7
+go get github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.2.7
+```
+
+---
+
 # Release v0.2.6 (2026-03-26)
 
 Maintenance release switching npm publishing to OIDC trusted publishing, upgrading the Node.js toolchain, and fixing the PyPI badge in the Python SDK README.

--- a/memory-bank/release-process.md
+++ b/memory-bank/release-process.md
@@ -1,6 +1,28 @@
 # Release Process — Pulumi Lagoon Provider
 
-**Last Updated**: 2026-03-26
+**Last Updated**: 2026-03-27
+
+## Claude Code Automation
+
+Two Claude Code tools assist with releases:
+
+### `/release` skill
+
+Invoke with `/release` in Claude Code. Walks through the complete release interactively:
+- Prompts for the target version
+- Runs the `release-validator` agent as a pre-flight check
+- Creates a worktree, runs `make release-prep`, updates the changelog
+- Guides through PR, both git tags, and GitHub release creation
+- Provides a post-release verification checklist
+
+### `release-validator` agent
+
+Pre-flight checklist runner. Used automatically by `/release`, or invoke manually:
+> "Run the release-validator for v0.X.Y"
+
+Checks: version consistency across all SDK manifests, test passage, go vet, changelog entry, clean working tree, and CI status on main. Reports PASS/FAIL per check with remediation steps.
+
+---
 
 ## Pre-Release: `make release-prep`
 

--- a/provider/cmd/pulumi-resource-lagoon/main.go
+++ b/provider/cmd/pulumi-resource-lagoon/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is set at build time via ldflags.
-var Version = "0.2.6"
+var Version = "0.2.7"
 
 func main() {
 	provider, err := lagoon.NewProvider(Version)

--- a/provider/schema.json
+++ b/provider/schema.json
@@ -1,7 +1,7 @@
 {
   "name": "lagoon",
   "displayName": "Lagoon",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Manage Lagoon hosting platform resources as infrastructure-as-code.",
   "keywords": [
     "lagoon",

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tag1consulting/pulumi-lagoon",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "keywords": [
         "lagoon",
         "hosting",
@@ -27,7 +27,7 @@
     "pulumi": {
         "resource": true,
         "name": "lagoon",
-        "version": "0.2.6",
+        "version": "0.2.7",
         "server": "https://github.com/tag1consulting/pulumi-lagoon-provider/releases/download/v${VERSION}"
     }
 }

--- a/sdk/python/pulumi_lagoon/pulumi-plugin.json
+++ b/sdk/python/pulumi_lagoon/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "lagoon",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "server": "https://github.com/tag1consulting/pulumi-lagoon-provider/releases/download/v${VERSION}"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["lagoon", "hosting", "kubernetes", "pulumi"]
   readme = "README.md"
   requires-python = ">=3.9"
-  version = "0.2.6"
+  version = "0.2.7"
   license = "Apache-2.0"
   [project.urls]
     Homepage = "https://github.com/tag1consulting/pulumi-lagoon-provider"


### PR DESCRIPTION
## Summary

- Bump version to 0.2.7 across provider binary, schema, and all SDK manifests
- Regenerate Python, Node.js, and Go SDKs
- Update \`RELEASE_NOTES.md\` with changes since v0.2.6
- Update \`memory-bank/release-process.md\` with Claude Code automation docs

## Changes since v0.2.6

- **Remove legacy Python dynamic provider** (#82, closes #77): Dead code cleanup; native Go provider has been authoritative since v0.2.0
- **Expanded CI test coverage** (#80): Node.js pack+install, Go SDK vet, all 12 Python imports
- **Go module proxy warm-up** (#79): \`warm-go-proxy\` CI job primes the proxy on release
- **Go SDK LICENSE for pkg.go.dev** (#85): Automated LICENSE copy during SDK regen
- **Multi-cluster docs** (#97, #100, #101): Keycloak secret name fix, jq prerequisite, scripts vs symlinks correction
- **Single-cluster setup** (#95, #96): Virtualenv path, cluster name default, PyJWT dep
- **Release tooling** (#81, #93): sed anchor fix, CLAUDE.md/RELEASE_NOTES.md in version bump automation

## Test plan

- [x] CI: Go tests pass (\`test-go.yml\`)
- [x] CI: SDK build checks pass (\`test-build.yml\`)
- [ ] After merge: tag \`v0.2.7\` and \`sdk/go/lagoon/v0.2.7\`, then create GitHub release to trigger publish