### PR TITLE
Fix: upgrade actions/setup-node@v4 to @v5 (closes #103)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -140,7 +140,7 @@ jobs:
         node-version: ['22', '24']
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -217,7 +217,7 @@ jobs:
       contents: read
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
 
@@ -106,7 +106,7 @@ jobs:
         node-version: ['22', '24']
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## Summary

Upgrades all `actions/setup-node@v4` references to `@v5` to eliminate Node.js 20 deprecation warnings in CI.

- 3 occurrences in `.github/workflows/publish.yml`
- 2 occurrences in `.github/workflows/test-build.yml`

## Why

`actions/setup-node@v4` runs the action itself on Node.js 20, which GitHub Actions is deprecating:
- **June 2, 2026** — Node.js 24 becomes the forced default
- **September 16, 2026** — Node.js 20 removed from runners entirely

`actions/setup-node@v5` runs on Node.js 24. This does not change the Node.js versions used for building/testing (still `['22', '24']` per the test matrix).

## Test plan

- [ ] CI: `Test Build (PRs)` passes with no Node.js 20 deprecation warnings
- [ ] CI: Go tests pass