### PR TITLE
Fix: add workflow-level permissions to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   build-python:
     name: Build Python distribution


### PR DESCRIPTION
## Summary

Adds a top-level \`permissions: contents: read\` block to \`publish.yml\` to restrict the default \`GITHUB_TOKEN\` permissions for all jobs.

## Why

GitHub code scanning (CodeQL) flagged two jobs missing explicit permissions blocks:
- Alert #2: \`test-install-python\` job
- Alert #4: \`build-python\` job

Without an explicit \`permissions\` block, jobs run with the repository's default \`GITHUB_TOKEN\` permissions, which may be broader than needed. A workflow-level \`permissions: contents: read\` sets a minimal default for all jobs.

Jobs that need broader permissions (\`publish-testpypi\`, \`publish-pypi\`, \`publish-npm\`) already have explicit job-level \`permissions\` blocks — these override the workflow-level default and are unaffected by this change.

## Also done (not in this PR)

Alert #3 (\`py/incomplete-url-substring-sanitization\` in test code) was dismissed as a false positive directly on GitHub — the flagged \`startswith()\` call is a Kubernetes annotation key prefix check in test code, not URL sanitization.

## Test plan

- [x] CI passes
- [ ] Code scanning alerts #2 and #4 resolve as fixed after merge