### PR TITLE
Fix: replace invalid JSONPath 'contains' filter in ensure-knex-migrations.sh (closes #117)

### DIFF
--- a/scripts/ensure-knex-migrations.sh
+++ b/scripts/ensure-knex-migrations.sh
@@ -103,14 +103,22 @@ check_knex_migrations() {
 
     log_info "Checking if Knex migrations have been run..."
 
-    # First, check if the migratedb job completed successfully (works for all versions)
-    local job_status
-    job_status=$(kubectl --context "$KUBE_CONTEXT" -n "$LAGOON_NAMESPACE" get jobs \
-        -o jsonpath='{.items[?(@.metadata.name contains "migratedb")].status.succeeded}' 2>/dev/null | head -1)
+    # First, check if the migratedb job completed successfully (works for all versions).
+    # Note: Kubernetes JSONPath does not support substring filters like 'contains';
+    # get job names as plain text and use grep to find a migratedb job, then query
+    # that specific job's status with a valid JSONPath field expression.
+    local migratedb_job
+    migratedb_job=$(kubectl --context "$KUBE_CONTEXT" -n "$LAGOON_NAMESPACE" get jobs \
+        -o name 2>/dev/null | grep migratedb | head -1 | cut -d/ -f2)
 
-    if [ "$job_status" = "1" ]; then
-        log_info "Migration job completed successfully - assuming migrations are applied"
-        return 0
+    if [ -n "$migratedb_job" ]; then
+        local job_status
+        job_status=$(kubectl --context "$KUBE_CONTEXT" -n "$LAGOON_NAMESPACE" get job "$migratedb_job" \
+            -o jsonpath='{.status.succeeded}' 2>/dev/null)
+        if [ "$job_status" = "1" ]; then
+            log_info "Migration job '$migratedb_job' completed successfully - assuming migrations are applied"
+            return 0
+        fi
     fi
 
     # Fallback: Try to check the openshift table directly using node


### PR DESCRIPTION
## Summary

Fixes the false-positive migration check in `scripts/ensure-knex-migrations.sh` (#117).

The original code used `?(@.metadata.name contains "migratedb")` in a Kubernetes JSONPath filter. The `contains` operator is not valid in Kubernetes JSONPath (only `==` is supported in filter expressions). The invalid filter silently produced no matches — the early-return shortcut never fired, and the script always fell through to the heavier exec-into-pod check.

On Lagoon v2.31.0 (migrations run via init container, no `migratedb` job), this had no functional impact. However, the bug could mask real migration failures in configurations where a `migratedb` job does exist.

## Fix

Replaced the invalid JSONPath approach with a two-step grep-based lookup:

1. `kubectl get jobs -o name | grep migratedb | head -1` — finds a migratedb job by substring match (works regardless of exact job name prefix across presets)
2. If found, `kubectl get job <name> -o jsonpath='{.status.succeeded}'` — queries that specific job's status using a valid JSONPath field expression
3. If no migratedb job exists (e.g., Lagoon v2.31.0), falls through to the exec-into-pod check as before

This matches the pattern already used correctly at line 151 for the fallback check.

## Test plan

- [ ] Deploy Lagoon v2.31.0 (no migratedb job): `LAGOON_PRESET=single ./scripts/ensure-knex-migrations.sh` — should fall through to exec path and report "openshift table exists", not false-positive on job check
- [ ] Deploy Lagoon v2.30.0 or earlier (has migratedb job): verify the job-status shortcut fires correctly when the job succeeded