### PR TITLE
Config: ignore dependabot PRs in CodeRabbit auto-review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    ignore_usernames:
+      - "dependabot[bot]"
 chat:
   auto_reply: true
 tone_instructions: "Provide architectural insights on system design, scalability, and long-term maintainability."


### PR DESCRIPTION
## Summary

- Adds `ignore_usernames: ["dependabot[bot]"]` to the `auto_review` section of `.coderabbit.yaml`
- Prevents CodeRabbit from automatically reviewing Dependabot PRs

## Test plan

- [ ] Verify next Dependabot PR does not trigger a CodeRabbit review