### PR TITLE
Fix GoReleaser before.hooks syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,8 +2,7 @@ version: 2
 
 before:
   hooks:
-    - cmd: go mod tidy
-      dir: provider
+    - cd provider && go mod tidy
 
 builds:
   - id: pulumi-resource-lagoon


### PR DESCRIPTION
## Summary

- Fix `.goreleaser.yml` `before.hooks` to use plain string syntax instead of unsupported `cmd`/`dir` map syntax

GoReleaser v2's `before.hooks` expects a list of strings. The `cmd`/`dir` map format is only supported in `builds[].hooks.pre`/`builds[].hooks.post`.

This caused the v0.2.8 publish workflow to fail with `yaml: unmarshal errors: line 5: cannot unmarshal !!map into string`, blocking provider binary and SDK publishing.

Closes #133

## Test plan

- [ ] Merge and re-run the publish workflow (or delete/recreate the v0.2.8 release) to verify GoReleaser succeeds
- [ ] Confirm provider binaries are attached to the GitHub release
- [ ] Confirm PyPI and npm packages are published