### PR TITLE
Release v0.2.9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This provider allows you to declaratively manage Lagoon hosting platform resourc
 
 ## Project Status
 
-**Status**: v0.2.8 Released (Native Go Provider)
+**Status**: v0.2.9 Released (Native Go Provider)
 
 The provider is available on PyPI (`pip install pulumi-lagoon`), npm (`@tag1consulting/pulumi-lagoon`), and Go (`github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon`). v0.2.x ships the native Go provider with generated multi-language SDKs, replacing the Python dynamic provider.
 

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ clean-all: clean
 # Go Provider (Native)
 #==============================================================================
 
-PROVIDER_VERSION ?= 0.2.8
+PROVIDER_VERSION ?= 0.2.9
 PROVIDER_BIN     := provider/bin/pulumi-resource-lagoon
 GO_BIN           ?= $(if $(GOPATH),$(GOPATH)/bin,$(HOME)/go/bin)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Pulumi provider for managing [Lagoon](https://www.lagoon.sh/) resources as inf
 
 This provider enables you to manage Lagoon hosting platform resources (projects, environments, variables, deploy targets, notifications, tasks, etc.) using Pulumi, with native SDKs for Python, TypeScript/JavaScript, and Go.
 
-**Status**: v0.2.8 — Native Go Provider
+**Status**: v0.2.9 — Native Go Provider
 
 ## Supported Resources
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+# Release v0.2.9 (2026-03-30)
+
+Patch release fixing the GoReleaser configuration that prevented v0.2.8 provider binaries and SDK packages from being published.
+
+## Bug Fixes
+
+- **Fix GoReleaser `before.hooks` syntax** (#134, closes #133): The `.goreleaser.yml` used an unsupported map syntax (`cmd:`/`dir:`) for `before.hooks`, which expects plain strings in GoReleaser v2. This caused the publish workflow to fail on the v0.2.8 release, blocking provider binary and SDK publishing.
+
+## Installation
+
+```bash
+pip install pulumi-lagoon==0.2.9
+npm install @tag1consulting/pulumi-lagoon@0.2.9
+go get github.com/tag1consulting/pulumi-lagoon-provider/sdk/go/lagoon@v0.2.9
+```
+
+---
+
 # Release v0.2.8 (2026-03-30)
 
 Feature release adding route resource management, Pulumi Registry listing, and fixing several state-corruption bugs.

--- a/provider/cmd/pulumi-resource-lagoon/main.go
+++ b/provider/cmd/pulumi-resource-lagoon/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is set at build time via ldflags.
-var Version = "0.2.8"
+var Version = "0.2.9"
 
 func main() {
 	provider, err := lagoon.NewProvider(Version)

--- a/provider/schema.json
+++ b/provider/schema.json
@@ -1,7 +1,7 @@
 {
   "name": "lagoon",
   "displayName": "Lagoon",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Manage Lagoon hosting platform resources as infrastructure-as-code.",
   "keywords": [
     "lagoon",

--- a/sdk/go/lagoon/internal/pulumiUtilities.go
+++ b/sdk/go/lagoon/internal/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/tag1consulting/pulumi-lagoon-provider"))
-	version := semver.MustParse("0.2.8")
+	version := semver.MustParse("0.2.9")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 	defaults = append(defaults, pulumi.PluginDownloadURL("github://api.github.com/tag1consulting/pulumi-lagoon-provider"))
-	version := semver.MustParse("0.2.8")
+	version := semver.MustParse("0.2.9")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/go/lagoon/pulumi-plugin.json
+++ b/sdk/go/lagoon/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "lagoon",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "server": "github://api.github.com/tag1consulting/pulumi-lagoon-provider"
 }

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tag1consulting/pulumi-lagoon",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "keywords": [
         "lagoon",
         "hosting",
@@ -27,7 +27,7 @@
     "pulumi": {
         "resource": true,
         "name": "lagoon",
-        "version": "0.2.8",
+        "version": "0.2.9",
         "server": "github://api.github.com/tag1consulting/pulumi-lagoon-provider"
     }
 }

--- a/sdk/python/pulumi_lagoon/pulumi-plugin.json
+++ b/sdk/python/pulumi_lagoon/pulumi-plugin.json
@@ -1,6 +1,6 @@
 {
   "resource": true,
   "name": "lagoon",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "server": "github://api.github.com/tag1consulting/pulumi-lagoon-provider"
 }

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -5,7 +5,7 @@
   keywords = ["lagoon", "hosting", "kubernetes", "pulumi"]
   readme = "README.md"
   requires-python = ">=3.9"
-  version = "0.2.8"
+  version = "0.2.9"
   license = "Apache-2.0"
   [project.urls]
     Homepage = "https://github.com/tag1consulting/pulumi-lagoon-provider"


### PR DESCRIPTION
## Summary

- Bump version to v0.2.9 across all provider artifacts and SDKs
- Add release notes for v0.2.9

Patch release to publish provider binaries and SDK packages that were blocked by the GoReleaser config bug fixed in #134.

## Test plan

- [ ] Merge, tag, and create GitHub release
- [ ] Verify GoReleaser succeeds in the publish workflow
- [ ] Confirm provider binaries attached to the release
- [ ] Confirm PyPI and npm packages published