### PR TITLE
Fix GoReleaser hooks: wrap in bash for shell builtins

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ version: 2
 
 before:
   hooks:
-    - cd provider && go mod tidy
+    - bash -c "cd provider && go mod tidy"
 
 builds:
   - id: pulumi-resource-lagoon


### PR DESCRIPTION
## Summary

- Wrap GoReleaser `before.hooks` command in `bash -c` since GoReleaser execs hooks directly without a shell

Follow-up to #134. GoReleaser doesn't use a shell to execute `before.hooks` — it calls `exec` directly. So `cd` (a shell builtin) fails with `exec: "cd": executable file not found in $PATH`.

**Fix:** `bash -c "cd provider && go mod tidy"`

Closes #133

## Test plan

- [ ] Merge, bump to v0.2.10, tag, and create release
- [ ] Verify GoReleaser succeeds in the publish workflow