### PR TITLE
CI: upgrade upload-artifact, download-artifact, setup-dotnet to v5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
         working-directory: sdk/python
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-python
           path: sdk/python/dist/
@@ -100,7 +100,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-python
           path: dist/
@@ -148,7 +148,7 @@ jobs:
         working-directory: sdk/nodejs
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-nodejs
           path: |
@@ -171,7 +171,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-nodejs
           path: sdk/nodejs/
@@ -200,7 +200,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-python
           path: dist/
@@ -222,7 +222,7 @@ jobs:
       id-token: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-python
           path: dist/
@@ -249,7 +249,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-nodejs
           path: sdk/nodejs/
@@ -272,7 +272,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0'
 
@@ -304,7 +304,7 @@ jobs:
         working-directory: sdk/dotnet
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-dotnet
           path: sdk/dotnet/dist/
@@ -315,12 +315,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0'
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-dotnet
           path: dist/
@@ -349,12 +349,12 @@ jobs:
       id-token: write
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0'
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-dotnet
           path: dist/

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: sdk/python
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist
           path: sdk/python/dist/
@@ -61,7 +61,7 @@ jobs:
         working-directory: sdk/nodejs
 
       - name: Upload Node.js artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-nodejs
           path: |
@@ -84,7 +84,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist
           path: dist/
@@ -111,7 +111,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-nodejs
           path: sdk/nodejs/
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0'
 
@@ -148,7 +148,7 @@ jobs:
         working-directory: sdk/dotnet
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: dist-dotnet
           path: sdk/dotnet/dist/
@@ -159,12 +159,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0'
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dist-dotnet
           path: dist/


### PR DESCRIPTION
## Summary

Resolves #141.

Upgrades three GitHub Actions from v4 (Node.js 20) to v5 (Node.js 24) before the June 2, 2026 forced migration deadline.

| Action | Before | After |
|--------|--------|-------|
| `actions/upload-artifact` | `@v4` | `@v5` |
| `actions/download-artifact` | `@v4` | `@v5` |
| `actions/setup-dotnet` | `@v4` | `@v5` |

Both `.github/workflows/test-build.yml` and `.github/workflows/publish.yml` updated.

## Test plan

- [ ] CI passes on this PR (test-build.yml runs on PR open)
- [ ] All build and test jobs complete without Node.js deprecation warnings