### PR TITLE
Fix: resolve GoReleaser and GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,18 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: provider/go.mod
           cache-dependency-path: provider/go.sum
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           args: release --clean
           version: '~> 2'
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -166,7 +166,7 @@ jobs:
         node-version: ['22', '24']
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -243,7 +243,7 @@ jobs:
       contents: read
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -106,7 +106,7 @@ jobs:
         node-version: ['22', '24']
     steps:
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,11 @@ builds:
 
 archives:
   - id: archive
-    format: tar.gz
+    formats: tar.gz
     name_template: "pulumi-resource-lagoon-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
Closes #137.

## What's changed

Three files, 10 line changes — all version bumps and field renames, no logic changes.

### `.goreleaser.yml`
GoReleaser v2.6 renamed `archives[].format` to `archives[].formats` (and `format_overrides[].format` to `format_overrides[].formats`). These were still using the deprecated names, which print warnings on every release run.

### `.github/workflows/publish.yml`
The `goreleaser` job was missed by PR #144 and was still running on three Node.js 20 actions:
- `actions/checkout` v4 → v6
- `actions/setup-go` v5 → v6
- `goreleaser/goreleaser-action` v6 → v7
- `actions/setup-node` v5 → v6 (3 occurrences in the SDK publish jobs)

### `.github/workflows/test-build.yml`
- `actions/setup-node` v5 → v6 (2 occurrences)

`test-go.yml` was already fully up to date and is untouched.

## Testing
The `test-build.yml` workflow runs automatically on this PR and will validate the `setup-node@v6` upgrade. The GoReleaser and goreleaser-action changes will be exercised on the next release publish.