### PR TITLE
Update examples and docs to use top-level import paths

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -30,7 +30,7 @@ const provider = new lagoon.Provider("lagoon", {
     token: "your-lagoon-jwt-token",
 });
 
-const project = new lagoon.lagoon.Project("my-project", {
+const project = new lagoon.Project("my-project", {
     name: "my-project",
     gitUrl: "git@github.com:my-org/my-repo.git",
     deploytargetId: 1,
@@ -50,7 +50,7 @@ provider = lagoon.Provider("lagoon",
     token="your-lagoon-jwt-token",
 )
 
-project = lagoon.lagoon.Project("my-project",
+project = lagoon.Project("my-project",
     name="my-project",
     git_url="git@github.com:my-org/my-repo.git",
     deploytarget_id=1,

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -22,7 +22,7 @@ The notification workflow in Lagoon involves two steps:
 Creates a Slack notification configuration.
 
 ```python
-from pulumi_lagoon.lagoon import NotificationSlack, NotificationSlackArgs
+from pulumi_lagoon import NotificationSlack, NotificationSlackArgs
 
 slack_alerts = NotificationSlack("deploy-alerts",
     NotificationSlackArgs(
@@ -51,7 +51,7 @@ slack_alerts = NotificationSlack("deploy-alerts",
 Creates a RocketChat notification configuration.
 
 ```python
-from pulumi_lagoon.lagoon import NotificationRocketChat, NotificationRocketChatArgs
+from pulumi_lagoon import NotificationRocketChat, NotificationRocketChatArgs
 
 rocketchat_alerts = NotificationRocketChat("team-chat",
     NotificationRocketChatArgs(
@@ -74,7 +74,7 @@ rocketchat_alerts = NotificationRocketChat("team-chat",
 Creates an Email notification configuration.
 
 ```python
-from pulumi_lagoon.lagoon import NotificationEmail, NotificationEmailArgs
+from pulumi_lagoon import NotificationEmail, NotificationEmailArgs
 
 email_ops = NotificationEmail("ops-team",
     NotificationEmailArgs(
@@ -95,7 +95,7 @@ email_ops = NotificationEmail("ops-team",
 Creates a Microsoft Teams notification configuration.
 
 ```python
-from pulumi_lagoon.lagoon import NotificationMicrosoftTeams, NotificationMicrosoftTeamsArgs
+from pulumi_lagoon import NotificationMicrosoftTeams, NotificationMicrosoftTeamsArgs
 
 teams_alerts = NotificationMicrosoftTeams("teams-alerts",
     NotificationMicrosoftTeamsArgs(
@@ -117,7 +117,7 @@ Links a notification to a project. This enables the project to receive notificat
 
 ```python
 import pulumi
-from pulumi_lagoon.lagoon import (
+from pulumi_lagoon import (
     NotificationSlack, NotificationSlackArgs,
     Project, ProjectArgs,
     ProjectNotification, ProjectNotificationArgs,
@@ -171,7 +171,7 @@ Here's a complete example showing how to set up multiple notifications for a pro
 
 ```python
 import pulumi
-from pulumi_lagoon.lagoon import (
+from pulumi_lagoon import (
     NotificationEmail, NotificationEmailArgs,
     NotificationMicrosoftTeams, NotificationMicrosoftTeamsArgs,
     NotificationSlack, NotificationSlackArgs,
@@ -258,7 +258,7 @@ A single notification can be linked to multiple projects:
 
 ```python
 import pulumi
-from pulumi_lagoon.lagoon import (
+from pulumi_lagoon import (
     NotificationSlack, NotificationSlackArgs,
     Project, ProjectArgs,
     ProjectNotification, ProjectNotificationArgs,
@@ -319,7 +319,7 @@ After importing, add the corresponding resource definition to your Pulumi code:
 
 ```python
 import pulumi
-from pulumi_lagoon.lagoon import NotificationSlack, NotificationSlackArgs
+from pulumi_lagoon import NotificationSlack, NotificationSlackArgs
 
 # After importing "deploy-alerts"
 slack_alerts = NotificationSlack("my-slack",

--- a/examples/multi-cluster/lagoon/project.py
+++ b/examples/multi-cluster/lagoon/project.py
@@ -13,7 +13,7 @@ from typing import Optional
 import pulumi
 import pulumi_lagoon
 from config import DomainConfig
-from pulumi_lagoon.lagoon import (
+from pulumi_lagoon import (
     DeployTarget,
     DeployTargetArgs,
     DeployTargetConfig,

--- a/examples/simple-project/__main__.py
+++ b/examples/simple-project/__main__.py
@@ -15,7 +15,7 @@ Prerequisites:
 
 import pulumi
 import pulumi_lagoon
-from pulumi_lagoon.lagoon import (
+from pulumi_lagoon import (
     Environment,
     EnvironmentArgs,
     NotificationEmail,

--- a/examples/single-cluster/__main__.py
+++ b/examples/single-cluster/__main__.py
@@ -51,7 +51,7 @@ from registry import install_harbor
 
 # Import pulumi_lagoon native provider for deploy targets and projects
 import pulumi_lagoon
-from pulumi_lagoon.lagoon import DeployTarget, DeployTargetArgs, Project, ProjectArgs
+from pulumi_lagoon import DeployTarget, DeployTargetArgs, Project, ProjectArgs
 
 # =============================================================================
 # Configuration


### PR DESCRIPTION
## Summary

Now that PR #150 added top-level re-exports for Python and Node.js SDKs, update all examples and documentation to use the shorter import paths:

- **Python**: `from pulumi_lagoon import Project` (was `from pulumi_lagoon.lagoon import Project`)
- **TypeScript**: `lagoon.Project` (was `lagoon.lagoon.Project`)

Files updated:
- `examples/simple-project/__main__.py`
- `examples/single-cluster/__main__.py`
- `examples/multi-cluster/lagoon/project.py`
- `docs/notifications.md` (8 instances)
- `docs/_index.md` (TypeScript + Python examples — this is the Pulumi Registry landing page)

The old submodule paths continue to work for backwards compatibility. Go, C#, YAML, and `pulumi import` CLI commands are unchanged (those use URN tokens, not import paths).

## Test plan

- [x] CI passes (no functional changes, only import path updates in docs/examples) — all 13 checks green