### PR TITLE
ci: use PAT checkout for private ai-pr-review action

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -80,7 +80,10 @@ jobs:
 
       - name: Mask action repo token
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
-        run: echo "::add-mask::${{ secrets.AI_PR_REVIEW_TOKEN }}"
+        env:
+          TOKEN: ${{ secrets.AI_PR_REVIEW_TOKEN }}
+        run: |
+          if [[ -n "$TOKEN" ]]; then echo "::add-mask::$TOKEN"; fi
 
       - uses: actions/checkout@v6
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -43,8 +43,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
 
-      # For workflow_dispatch: resolve PR number from ref when not supplied directly.
-      # Resolves a branch name or SHA to the open PR targeting the default branch.
       - name: Resolve PR number
         id: resolve-pr
         if: github.event_name == 'workflow_dispatch'
@@ -60,13 +58,11 @@ jobs:
             echo "base_ref=${base_ref}" >> "$GITHUB_OUTPUT"
             echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
           else
-            # Resolve the ref to a commit SHA, then find the open PR for it
             head_sha=$(git rev-parse HEAD)
             echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
             pr_json=$(gh pr list --state open --json number,baseRefName,headRefOid \
               --jq ".[] | select(.headRefOid | startswith(\"${head_sha:0:7}\"))" | head -1)
             if [[ -z "$pr_json" ]]; then
-              # Fall back: find any open PR whose head branch matches the ref input
               pr_json=$(gh pr list --state open --head "$INPUT_REF" \
                 --json number,baseRefName,headRefOid | jq '.[0]')
             fi
@@ -78,7 +74,16 @@ jobs:
             echo "base_ref=$(echo "$pr_json" | jq -r '.baseRefName')" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: tag1consulting/ai-pr-review@main
+      - name: Mask action repo token
+        run: echo "::add-mask::${{ secrets.AI_PR_REVIEW_TOKEN }}"
+
+      - uses: actions/checkout@v4
+        with:
+          repository: tag1consulting/ai-pr-review
+          token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
+          path: .ai-pr-review
+
+      - uses: ./.ai-pr-review
         with:
           provider: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
           api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -43,6 +43,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
 
+      # For workflow_dispatch: resolve PR number from ref when not supplied directly.
+      # Resolves a branch name or SHA to the open PR targeting the default branch.
       - name: Resolve PR number
         id: resolve-pr
         if: github.event_name == 'workflow_dispatch'
@@ -58,11 +60,13 @@ jobs:
             echo "base_ref=${base_ref}" >> "$GITHUB_OUTPUT"
             echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
           else
+            # Resolve the ref to a commit SHA, then find the open PR for it
             head_sha=$(git rev-parse HEAD)
             echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
             pr_json=$(gh pr list --state open --json number,baseRefName,headRefOid \
               --jq ".[] | select(.headRefOid | startswith(\"${head_sha:0:7}\"))" | head -1)
             if [[ -z "$pr_json" ]]; then
+              # Fall back: find any open PR whose head branch matches the ref input
               pr_json=$(gh pr list --state open --head "$INPUT_REF" \
                 --json number,baseRefName,headRefOid | jq '.[0]')
             fi
@@ -78,7 +82,7 @@ jobs:
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         run: echo "::add-mask::${{ secrets.AI_PR_REVIEW_TOKEN }}"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         with:
           repository: tag1consulting/ai-pr-review

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -75,15 +75,24 @@ jobs:
           fi
 
       - name: Mask action repo token
+        if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         run: echo "::add-mask::${{ secrets.AI_PR_REVIEW_TOKEN }}"
 
       - uses: actions/checkout@v4
+        if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         with:
           repository: tag1consulting/ai-pr-review
+          ref: main
           token: ${{ secrets.AI_PR_REVIEW_TOKEN }}
+          persist-credentials: false
           path: .ai-pr-review
 
+      - name: Skip AI review (fork PR — AI_PR_REVIEW_TOKEN unavailable)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+        run: echo "Skipping AI review for fork PR — repository secrets are unavailable in this context."
+
       - uses: ./.ai-pr-review
+        if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
         with:
           provider: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
           api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}


### PR DESCRIPTION
## Summary

- Replaces the broken `uses: tag1consulting/ai-pr-review@main` reference with the PAT checkout pattern
- Adds `::add-mask` on the PAT token as defense-in-depth

## Background

`ai-pr-review` is a **private** repository. GitHub Actions cannot resolve private composite actions from a **public** repository via a direct `uses: org/repo@ref` reference — the runner has no credentials to clone the private repo. The `access_level: organization` sharing setting only enables private-to-private repo sharing, not public-to-private.

The fix uses the standard PAT checkout pattern:

1. Check out `ai-pr-review` into `.ai-pr-review/` using a fine-grained PAT (`AI_PR_REVIEW_TOKEN`, scoped to `Contents:Read` on `ai-pr-review` only)
2. Reference it as a local composite action with `uses: ./.ai-pr-review`

The action's `SCRIPT_DIR` uses `BASH_SOURCE[0]`, so all helpers, prompts, and language profiles resolve correctly from the checkout path.

## Secret safety

| Layer | Protection |
|-------|-----------|
| GitHub auto-masking | `secrets.*` values masked in logs by default |
| `::add-mask` for PAT | Added in this PR — masks `AI_PR_REVIEW_TOKEN` before the checkout step |
| `::add-mask` in action.yml | Added in ai-pr-review PR #50 — masks `api-key` and `github-token` inputs |
| `::add-mask` in review.sh | Added in ai-pr-review PR #50 — masks all provider key env vars |
| Fine-grained PAT scope | Read-only access to a single repo only |

## Prerequisites

The `AI_PR_REVIEW_TOKEN` secret must be set on this repository (or at org level). It should be a fine-grained PAT with `Contents: Read` on `tag1consulting/ai-pr-review` only.

## Test plan

- [ ] Merge this PR; open a new test PR and verify the AI review runs successfully
- [ ] Confirm review comments are posted on the PR
- [ ] Check action logs — no API keys or PAT value should appear (shown as `***`)
- [ ] Verify `workflow_dispatch` still works with explicit `pr_number` and with just `ref`
- [ ] Verify skip conditions work (draft PR, renovate/dependabot, `skip-ai-review` label)