### PR TITLE
fix(config): trim whitespace from JWT secret and token inputs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -61,6 +61,27 @@ ensure it exists before `pulumi up` runs.
   operation; if you see stale values persisting, confirm your Lagoon version
   honours null in `UpdateUserInput.patch`.
 
+## Bug Fixes
+
+### Fix JWT secret whitespace causing "invalid signature" (closes #171)
+
+The provider now trims leading/trailing whitespace from the `jwtSecret`, `token`,
+and `jwtAudience` configuration values before use. Previously, a trailing newline
+or space in the JWT secret (common when extracting from Kubernetes secrets via
+shell pipelines) would silently corrupt the HMAC signing key, producing tokens
+that the Lagoon API rejected with "Legacy token invalid: invalid signature".
+
+The same trimming is applied to `LAGOON_TOKEN` and `LAGOON_JWT_SECRET` environment
+variables.
+
+### Debug logging for token generation
+
+The provider now logs debug messages during `Configure` showing whether a token
+was generated from a JWT secret or loaded from an environment variable, along
+with the secret length and audience value. These messages are visible with
+`pulumi --logtostderr -v=9` and help diagnose authentication issues without
+exposing secret values.
+
 ---
 
 # Release v0.3.0 (2026-03-31)

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
+
+	p "github.com/pulumi/pulumi-go-provider"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/pulumi/pulumi-go-provider/infer"
@@ -52,11 +55,16 @@ func (c *LagoonConfig) Annotate(a infer.Annotator) {
 // Configure validates the config and prepares it for use.
 // Called by the Pulumi engine when the provider is configured.
 func (c *LagoonConfig) Configure(ctx context.Context) error {
-	// Track whether token was derived from JWTSecret (vs explicitly provided)
+	log := p.GetLogger(ctx)
+
+	c.Token = strings.TrimSpace(c.Token)
+	c.JWTSecret = strings.TrimSpace(c.JWTSecret)
+	c.JWTAudience = strings.TrimSpace(c.JWTAudience)
+
 	tokenFromSecret := false
 
-	// If no direct token, try generating from JWT secret
 	if c.Token == "" && c.JWTSecret != "" {
+		log.Debugf("Generating admin token from jwtSecret (%d bytes, audience=%q)", len(c.JWTSecret), c.JWTAudience)
 		token, err := c.generateAdminToken()
 		if err != nil {
 			return fmt.Errorf("failed to generate admin token from jwtSecret: %w", err)
@@ -65,15 +73,16 @@ func (c *LagoonConfig) Configure(ctx context.Context) error {
 		tokenFromSecret = true
 	}
 
-	// Also check env vars if nothing is configured yet
 	if c.Token == "" {
-		if envToken := os.Getenv("LAGOON_TOKEN"); envToken != "" {
+		if envToken := strings.TrimSpace(os.Getenv("LAGOON_TOKEN")); envToken != "" {
+			log.Debugf("Using token from LAGOON_TOKEN environment variable")
 			c.Token = envToken
 		}
 	}
 	if c.Token == "" {
-		if envSecret := os.Getenv("LAGOON_JWT_SECRET"); envSecret != "" {
-			c.JWTSecret = envSecret // Persist for token refresh in NewClient()
+		if envSecret := strings.TrimSpace(os.Getenv("LAGOON_JWT_SECRET")); envSecret != "" {
+			log.Debugf("Generating admin token from LAGOON_JWT_SECRET (%d bytes, audience=%q)", len(envSecret), c.JWTAudience)
+			c.JWTSecret = envSecret
 			token, err := generateAdminTokenFromSecret(envSecret, c.JWTAudience)
 			if err != nil {
 				return fmt.Errorf("failed to generate token from LAGOON_JWT_SECRET: %w", err)
@@ -88,8 +97,6 @@ func (c *LagoonConfig) Configure(ctx context.Context) error {
 			"or use LAGOON_TOKEN/LAGOON_JWT_SECRET environment variables")
 	}
 
-	// Clear JWTSecret if token was explicitly provided (not derived from secret)
-	// so NewClient() won't set up a refresh callback that overrides the explicit token
 	if !tokenFromSecret {
 		c.JWTSecret = ""
 	}

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -67,7 +67,10 @@ func TestGenerateAdminTokenFromSecret_DefaultAudience(t *testing.T) {
 		t.Fatalf("failed to parse token: %v", err)
 	}
 
-	claims := token.Claims.(jwt.MapClaims)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("expected MapClaims")
+	}
 	if claims["aud"] != "api.dev" {
 		t.Errorf("expected aud=api.dev (default), got %v", claims["aud"])
 	}
@@ -89,7 +92,10 @@ func TestGenerateAdminTokenFromSecret_Expiry(t *testing.T) {
 		t.Fatalf("failed to parse token: %v", err)
 	}
 
-	claims := token.Claims.(jwt.MapClaims)
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatal("expected MapClaims")
+	}
 
 	exp, err := claims.GetExpirationTime()
 	if err != nil {
@@ -339,17 +345,29 @@ func TestConfigure_TrimsJWTSecretWhitespace(t *testing.T) {
 			if err := cfg.Configure(context.TODO()); err != nil {
 				t.Fatalf("Configure failed: %v", err)
 			}
-			cleanToken, _ := jwt.Parse(cleanCfg.Token, func(t *jwt.Token) (any, error) {
+			cleanToken, err := jwt.Parse(cleanCfg.Token, func(t *jwt.Token) (any, error) {
 				return []byte(secret), nil
 			})
-			dirtyToken, _ := jwt.Parse(cfg.Token, func(t *jwt.Token) (any, error) {
+			if err != nil {
+				t.Fatalf("failed to parse clean token: %v", err)
+			}
+			dirtyToken, err := jwt.Parse(cfg.Token, func(t *jwt.Token) (any, error) {
 				return []byte(secret), nil
 			})
+			if err != nil {
+				t.Fatalf("failed to parse dirty token: %v", err)
+			}
 			if !dirtyToken.Valid {
 				t.Errorf("token generated from %q should be valid when verified with trimmed secret", tc.name)
 			}
-			cleanClaims := cleanToken.Claims.(jwt.MapClaims)
-			dirtyClaims := dirtyToken.Claims.(jwt.MapClaims)
+			cleanClaims, ok := cleanToken.Claims.(jwt.MapClaims)
+			if !ok {
+				t.Fatal("expected MapClaims from clean token")
+			}
+			dirtyClaims, ok := dirtyToken.Claims.(jwt.MapClaims)
+			if !ok {
+				t.Fatal("expected MapClaims from dirty token")
+			}
 			if cleanClaims["role"] != dirtyClaims["role"] || cleanClaims["aud"] != dirtyClaims["aud"] {
 				t.Errorf("claims mismatch between clean and whitespace-padded secret tokens")
 			}

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -294,6 +294,109 @@ func TestConfigure_TokenPrecedence(t *testing.T) {
 	}
 }
 
+func TestConfigure_TrimsJWTSecretWhitespace(t *testing.T) {
+	origToken := os.Getenv("LAGOON_TOKEN")
+	origSecret := os.Getenv("LAGOON_JWT_SECRET")
+	os.Unsetenv("LAGOON_TOKEN")
+	os.Unsetenv("LAGOON_JWT_SECRET")
+	defer func() {
+		if origToken != "" {
+			os.Setenv("LAGOON_TOKEN", origToken)
+		}
+		if origSecret != "" {
+			os.Setenv("LAGOON_JWT_SECRET", origSecret)
+		}
+	}()
+
+	secret := "test-secret-for-trimming"
+
+	cleanCfg := &LagoonConfig{
+		APIUrl:      "https://api.test/graphql",
+		JWTSecret:   secret,
+		JWTAudience: "api.dev",
+	}
+	if err := cleanCfg.Configure(context.TODO()); err != nil {
+		t.Fatalf("Configure (clean) failed: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		jwtSecret string
+	}{
+		{"trailing newline", secret + "\n"},
+		{"trailing space", secret + " "},
+		{"leading space", " " + secret},
+		{"leading and trailing whitespace", "  " + secret + "\t\n"},
+		{"trailing CRLF", secret + "\r\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &LagoonConfig{
+				APIUrl:      "https://api.test/graphql",
+				JWTSecret:   tc.jwtSecret,
+				JWTAudience: "api.dev",
+			}
+			if err := cfg.Configure(context.TODO()); err != nil {
+				t.Fatalf("Configure failed: %v", err)
+			}
+			cleanToken, _ := jwt.Parse(cleanCfg.Token, func(t *jwt.Token) (any, error) {
+				return []byte(secret), nil
+			})
+			dirtyToken, _ := jwt.Parse(cfg.Token, func(t *jwt.Token) (any, error) {
+				return []byte(secret), nil
+			})
+			if !dirtyToken.Valid {
+				t.Errorf("token generated from %q should be valid when verified with trimmed secret", tc.name)
+			}
+			cleanClaims := cleanToken.Claims.(jwt.MapClaims)
+			dirtyClaims := dirtyToken.Claims.(jwt.MapClaims)
+			if cleanClaims["role"] != dirtyClaims["role"] || cleanClaims["aud"] != dirtyClaims["aud"] {
+				t.Errorf("claims mismatch between clean and whitespace-padded secret tokens")
+			}
+		})
+	}
+}
+
+func TestConfigure_TrimsTokenWhitespace(t *testing.T) {
+	cfg := &LagoonConfig{
+		APIUrl: "https://api.test/graphql",
+		Token:  "  my-token\n",
+	}
+	if err := cfg.Configure(context.TODO()); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+	if cfg.Token != "my-token" {
+		t.Errorf("expected trimmed token 'my-token', got %q", cfg.Token)
+	}
+}
+
+func TestConfigure_TrimsEnvVarWhitespace(t *testing.T) {
+	origToken := os.Getenv("LAGOON_TOKEN")
+	origSecret := os.Getenv("LAGOON_JWT_SECRET")
+	os.Setenv("LAGOON_TOKEN", "  env-token\n")
+	os.Unsetenv("LAGOON_JWT_SECRET")
+	defer func() {
+		if origToken != "" {
+			os.Setenv("LAGOON_TOKEN", origToken)
+		} else {
+			os.Unsetenv("LAGOON_TOKEN")
+		}
+		if origSecret != "" {
+			os.Setenv("LAGOON_JWT_SECRET", origSecret)
+		}
+	}()
+
+	cfg := &LagoonConfig{
+		APIUrl: "https://api.test/graphql",
+	}
+	if err := cfg.Configure(context.TODO()); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+	if cfg.Token != "env-token" {
+		t.Errorf("expected trimmed env token 'env-token', got %q", cfg.Token)
+	}
+}
+
 func TestConfigure_JWTSecretGeneratesToken(t *testing.T) {
 	origToken := os.Getenv("LAGOON_TOKEN")
 	origSecret := os.Getenv("LAGOON_JWT_SECRET")


### PR DESCRIPTION
## Summary

Closes #171.

- Trim leading/trailing whitespace from `jwtSecret`, `token`, and `jwtAudience` config values in `Configure()` before use
- Apply the same trimming to `LAGOON_TOKEN` and `LAGOON_JWT_SECRET` environment variable values
- Add debug-level logging during `Configure` showing token source, secret length, and audience (visible with `pulumi --logtostderr -v=9`)

### Root cause

When extracting the JWT secret from Kubernetes (`kubectl get secret ... -o jsonpath=... | base64 -d`), shell pipelines or copy-paste can introduce trailing whitespace/newlines. The provider passed the raw string to `[]byte(jwtSecret)` for HMAC signing, producing a different key than what the Lagoon API uses. The resulting tokens were rejected with "Legacy token invalid: invalid signature".

The Lagoon API (Node.js) loads `JWTSECRET` from `process.env`, which doesn't have trailing whitespace since the Helm chart stores it via `stringData:`. So the API pod's key is clean, but the provider's copy had extra bytes.

### Investigation notes

Verified that:
- Both Go (`golang-jwt/jwt/v5`) and Node.js (`jsonwebtoken@^8.0.1`) use the same HS256 signing/verification
- Both treat the secret as a UTF-8 string (no base64 layer)
- The Lagoon API's `getCredentialsForLegacyToken` expects the same claims structure the provider generates (`role:admin`, `iss:lagoon-api`, `sub:lagoonadmin`, audience from `JWTAUDIENCE`)
- The Helm chart generates the secret via `randAlpha 32` (pure ASCII), so non-UTF-8 encoding is not the issue
- The only remaining vector is whitespace contamination during secret extraction/transport

## Test plan

- [x] `make go-build` compiles cleanly
- [x] `make go-test` passes all existing tests plus 3 new whitespace-trimming tests
- [x] `TestConfigure_TrimsJWTSecretWhitespace` — verifies tokens generated from whitespace-padded secrets are valid when verified with the trimmed secret (5 whitespace variants)
- [x] `TestConfigure_TrimsTokenWhitespace` — verifies explicit token values are trimmed
- [x] `TestConfigure_TrimsEnvVarWhitespace` — verifies LAGOON_TOKEN env var values are trimmed
- [ ] Integration test: verify provider can authenticate to a live Lagoon instance with a secret extracted via `kubectl`