### PR TITLE
fix(config): prevent provider replace cascade on config changes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+# Unreleased
+
+## Bug Fixes
+
+### Fix provider replace cascade on config changes (closes #177)
+
+The provider now implements `DiffConfig` to prevent unnecessary provider
+replacements when configuration values change. Previously, any change to
+`jwtSecret`, `token`, `apiUrl`, or other config fields triggered a provider
+replace, which cascaded into replacing every resource associated with the
+provider (DeployTarget, Project, etc.).
+
+No provider config change requires a replace — changing credentials or the API
+URL only affects how the provider authenticates, not which resources it can
+manage. The diff also normalizes whitespace so that trailing newlines in secrets
+(common with shell pipelines) are not detected as changes.
+
+---
+
 # Release v0.4.0 (2026-05-01)
 
 Feature release adding User resource management: full CRUD for Lagoon users, group role assignments, and platform role assignments.

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -132,6 +132,13 @@ func (c *LagoonConfig) NewClient() *client.Client {
 // resource associated with this provider instance.
 func (c *LagoonConfig) Diff(_ context.Context, req infer.DiffRequest[LagoonConfig, LagoonConfig]) (infer.DiffResponse, error) {
 	diff := map[string]p.PropertyDiff{}
+	normalizeAudience := func(v string) string {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return "api.dev"
+		}
+		return v
+	}
 	if strings.TrimSpace(req.Inputs.APIUrl) != strings.TrimSpace(req.State.APIUrl) {
 		diff["apiUrl"] = p.PropertyDiff{Kind: p.Update}
 	}
@@ -141,7 +148,7 @@ func (c *LagoonConfig) Diff(_ context.Context, req infer.DiffRequest[LagoonConfi
 	if strings.TrimSpace(req.Inputs.JWTSecret) != strings.TrimSpace(req.State.JWTSecret) {
 		diff["jwtSecret"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if strings.TrimSpace(req.Inputs.JWTAudience) != strings.TrimSpace(req.State.JWTAudience) {
+	if normalizeAudience(req.Inputs.JWTAudience) != normalizeAudience(req.State.JWTAudience) {
 		diff["jwtAudience"] = p.PropertyDiff{Kind: p.Update}
 	}
 	if req.Inputs.Insecure != req.State.Insecure {

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -125,6 +125,31 @@ func (c *LagoonConfig) NewClient() *client.Client {
 	return client.NewClient(c.APIUrl, c.Token, opts...)
 }
 
+// Diff compares old and new provider configuration. No config change requires a
+// provider replace — changing apiUrl, token, jwtSecret, or insecure only changes
+// how the provider authenticates or connects, not which resources it can manage.
+// Returning Update (never UpdateReplace) prevents the cascading replace of every
+// resource associated with this provider instance.
+func (c *LagoonConfig) Diff(_ context.Context, req infer.DiffRequest[LagoonConfig, LagoonConfig]) (infer.DiffResponse, error) {
+	diff := map[string]p.PropertyDiff{}
+	if strings.TrimSpace(req.Inputs.APIUrl) != strings.TrimSpace(req.State.APIUrl) {
+		diff["apiUrl"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if strings.TrimSpace(req.Inputs.Token) != strings.TrimSpace(req.State.Token) {
+		diff["token"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if strings.TrimSpace(req.Inputs.JWTSecret) != strings.TrimSpace(req.State.JWTSecret) {
+		diff["jwtSecret"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if strings.TrimSpace(req.Inputs.JWTAudience) != strings.TrimSpace(req.State.JWTAudience) {
+		diff["jwtAudience"] = p.PropertyDiff{Kind: p.Update}
+	}
+	if req.Inputs.Insecure != req.State.Insecure {
+		diff["insecure"] = p.PropertyDiff{Kind: p.Update}
+	}
+	return p.DiffResponse{HasChanges: len(diff) > 0, DetailedDiff: diff}, nil
+}
+
 // generateAdminToken creates an admin JWT from the configured secret.
 func (c *LagoonConfig) generateAdminToken() (string, error) {
 	return generateAdminTokenFromSecret(c.JWTSecret, c.JWTAudience)

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -506,6 +506,20 @@ func TestDiff_NeverReplace(t *testing.T) {
 	}
 }
 
+func TestDiff_AudienceDefaultEquivalence(t *testing.T) {
+	c := &LagoonConfig{}
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
+		Inputs: LagoonConfig{JWTAudience: ""},
+		State:  LagoonConfig{JWTAudience: "api.dev"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.HasChanges {
+		t.Error("empty string and 'api.dev' are runtime-equivalent; expected no changes")
+	}
+}
+
 func TestDiff_PartialChange(t *testing.T) {
 	c := &LagoonConfig{}
 	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
 func TestGenerateAdminTokenFromSecret(t *testing.T) {
@@ -443,5 +445,83 @@ func TestConfigure_JWTSecretGeneratesToken(t *testing.T) {
 	parts := strings.Split(cfg.Token, ".")
 	if len(parts) != 3 {
 		t.Errorf("expected JWT with 3 parts, got %d", len(parts))
+	}
+}
+
+// ==================== Diff (CustomDiff) ====================
+
+func TestDiff_NoChanges(t *testing.T) {
+	c := &LagoonConfig{}
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
+		Inputs: LagoonConfig{APIUrl: "https://api.test/graphql", Token: "tok", JWTAudience: "api.dev"},
+		State:  LagoonConfig{APIUrl: "https://api.test/graphql", Token: "tok", JWTAudience: "api.dev"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.HasChanges {
+		t.Error("expected no changes when config is identical")
+	}
+}
+
+func TestDiff_WhitespaceDifferencesIgnored(t *testing.T) {
+	c := &LagoonConfig{}
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
+		Inputs: LagoonConfig{Token: "my-token\n", JWTSecret: " secret "},
+		State:  LagoonConfig{Token: "my-token", JWTSecret: "secret"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.HasChanges {
+		t.Error("expected no changes when only whitespace differs")
+	}
+}
+
+func TestDiff_NeverReplace(t *testing.T) {
+	c := &LagoonConfig{}
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
+		Inputs: LagoonConfig{APIUrl: "https://new-api.test/graphql", Token: "new-tok", JWTSecret: "new-secret", JWTAudience: "api.prod", Insecure: true},
+		State:  LagoonConfig{APIUrl: "https://old-api.test/graphql", Token: "old-tok", JWTSecret: "old-secret", JWTAudience: "api.dev", Insecure: false},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Error("expected changes when all fields differ")
+	}
+	if resp.DeleteBeforeReplace {
+		t.Error("DeleteBeforeReplace must always be false for provider config")
+	}
+	for field, d := range resp.DetailedDiff {
+		if d.Kind != p.Update {
+			t.Errorf("field %q has Kind=%v, want Update (never replace)", field, d.Kind)
+		}
+	}
+	expectedFields := []string{"apiUrl", "token", "jwtSecret", "jwtAudience", "insecure"}
+	for _, f := range expectedFields {
+		if _, ok := resp.DetailedDiff[f]; !ok {
+			t.Errorf("expected %q in DetailedDiff", f)
+		}
+	}
+}
+
+func TestDiff_PartialChange(t *testing.T) {
+	c := &LagoonConfig{}
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
+		Inputs: LagoonConfig{APIUrl: "https://api.test/graphql", Token: "new-tok"},
+		State:  LagoonConfig{APIUrl: "https://api.test/graphql", Token: "old-tok"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Error("expected changes")
+	}
+	if len(resp.DetailedDiff) != 1 {
+		t.Errorf("expected 1 changed field, got %d", len(resp.DetailedDiff))
+	}
+	if _, ok := resp.DetailedDiff["token"]; !ok {
+		t.Error("expected 'token' in DetailedDiff")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #177.

Implements `CustomDiff` on `LagoonConfig` so that provider config changes produce `Update` diffs instead of `UpdateReplace`. This prevents the cascading replace of every resource associated with the provider when a config value changes.

### Root cause

The `pulumi-go-provider` `infer` package's default `DiffConfig` behavior replaces the provider on *any* config change ([pulumi/pulumi-go-provider#409](https://github.com/pulumi/pulumi-go-provider/issues/409)). When the provider is replaced, Pulumi replaces all resources associated with it — even if the effective configuration is identical.

In the reporter's case, non-deterministic Python dict serialization in a `pulumi-command` trigger caused the JWT secret to be "re-extracted" on every run (same value, different trigger string), which replaced the provider, which replaced every DeployTarget.

### Fix

Per the [Pulumi provider implementer's guide](https://github.com/pulumi/pulumi/blob/master/developer-docs/providers/implementers-guide.md#diffconfig):

> `DiffConfig` should only signal the need for replacement if the provider's new configuration makes it unable to manage resources associated with its old configuration.

No Lagoon provider config change requires a replace:
- `apiUrl` — changing the endpoint doesn't make old resources unmanageable (they're API-managed)
- `token` / `jwtSecret` — changing credentials doesn't affect resource identity
- `jwtAudience` / `insecure` — connection parameters, not resource state

The diff also normalizes whitespace via `TrimSpace` so trailing newlines (common from shell pipelines) are not detected as changes.

## Test plan

- [x] `make go-build` compiles cleanly
- [x] `make go-test` passes all tests
- [x] `TestDiff_NoChanges` — identical config produces no diff
- [x] `TestDiff_WhitespaceDifferencesIgnored` — trailing newlines/spaces not detected as changes
- [x] `TestDiff_NeverReplace` — all fields changed → all produce `Update` (never `UpdateReplace`), `DeleteBeforeReplace` is false
- [x] `TestDiff_PartialChange` — only changed fields appear in DetailedDiff