### PR TITLE
Refactor AI review to use container-action and add slash commands

### DIFF
--- a/.github/workflows/ai-review-commands.yml
+++ b/.github/workflows/ai-review-commands.yml
@@ -1,0 +1,161 @@
+name: AI PR Review — slash commands
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  handle-command:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/ai-pr-review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse command
+        id: cmd
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          command=$(echo "$COMMENT" | head -1 | tr -d '\r' | awk '{print $2}')
+          case "$command" in
+            rescan|review-full|skip|help)
+              echo "command=$command" >> "$GITHUB_OUTPUT"
+              echo "valid=true"       >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "valid=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: React — seen
+        if: steps.cmd.outputs.valid == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
+      - name: Reply with help text
+        if: steps.cmd.outputs.command == 'help'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "$(cat <<'EOF'
+          **AI PR Review commands:**
+          - `/ai-pr-review rescan` — force full diff re-review
+          - `/ai-pr-review review-full` — run all agents (full mode)
+          - `/ai-pr-review skip` — suppress the next automated review
+          - `/ai-pr-review help` — show this message
+          EOF
+          )"
+
+      - name: Add skip label
+        if: steps.cmd.outputs.command == 'skip'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --add-label skip-ai-review
+
+      - name: Checkout PR head
+        if: |
+          steps.cmd.outputs.command == 'rescan' ||
+          steps.cmd.outputs.command == 'review-full'
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
+
+      - name: Get PR metadata
+        if: |
+          steps.cmd.outputs.command == 'rescan' ||
+          steps.cmd.outputs.command == 'review-full'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_json=$(gh pr view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json baseRefName,headRefOid)
+          echo "base=$(echo "$pr_json" | jq -r .baseRefName)" >> "$GITHUB_OUTPUT"
+          echo "sha=$(echo  "$pr_json" | jq -r .headRefOid)"  >> "$GITHUB_OUTPUT"
+
+      - name: React — launching
+        if: |
+          steps.cmd.outputs.command == 'rescan' ||
+          steps.cmd.outputs.command == 'review-full'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=rocket
+
+      - name: Run review (rescan)
+        if: steps.cmd.outputs.command == 'rescan'
+        uses: tag1consulting/ai-pr-review/container-action@main
+        with:
+          provider: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
+          api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+          model-standard: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
+          model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.issue.number }}
+          base-ref: ${{ steps.pr.outputs.base }}
+          head-sha: ${{ steps.pr.outputs.sha }}
+          force-full-diff: 'true'
+          enable-suggestions: 'true'
+
+      - name: Run review (review-full)
+        if: steps.cmd.outputs.command == 'review-full'
+        uses: tag1consulting/ai-pr-review/container-action@main
+        with:
+          provider: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
+          api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+          model-standard: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
+          model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.issue.number }}
+          base-ref: ${{ steps.pr.outputs.base }}
+          head-sha: ${{ steps.pr.outputs.sha }}
+          review-mode: 'full'
+          force-full-diff: 'true'
+          enable-suggestions: 'true'
+
+      - name: React — done
+        if: |
+          success() && (
+            steps.cmd.outputs.command == 'rescan' ||
+            steps.cmd.outputs.command == 'review-full'
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content="+1"
+
+      - name: React — failed
+        if: |
+          failure() && (
+            steps.cmd.outputs.command == 'rescan' ||
+            steps.cmd.outputs.command == 'review-full'
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=confused

--- a/.github/workflows/ai-review-commands.yml
+++ b/.github/workflows/ai-review-commands.yml
@@ -37,17 +37,19 @@ jobs:
         if: steps.cmd.outputs.valid == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           gh api \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions" \
             -f content=eyes
 
       - name: Reply with help text
         if: steps.cmd.outputs.command == 'help'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh pr comment ${{ github.event.issue.number }} \
+          gh pr comment "$PR_NUMBER" \
             --repo ${{ github.repository }} \
             --body "$(cat <<'EOF'
           **AI PR Review commands:**
@@ -62,8 +64,9 @@ jobs:
         if: steps.cmd.outputs.command == 'skip'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh pr edit ${{ github.event.issue.number }} \
+          gh pr edit "$PR_NUMBER" \
             --repo ${{ github.repository }} \
             --add-label skip-ai-review
 
@@ -83,8 +86,9 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          pr_json=$(gh pr view ${{ github.event.issue.number }} \
+          pr_json=$(gh pr view "$PR_NUMBER" \
             --repo ${{ github.repository }} \
             --json baseRefName,headRefOid)
           echo "base=$(echo "$pr_json" | jq -r .baseRefName)" >> "$GITHUB_OUTPUT"
@@ -96,9 +100,10 @@ jobs:
           steps.cmd.outputs.command == 'review-full'
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           gh api \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions" \
             -f content=rocket
 
       - name: Run review (rescan)
@@ -142,9 +147,10 @@ jobs:
           )
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           gh api \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions" \
             -f content="+1"
 
       - name: React — failed
@@ -155,7 +161,8 @@ jobs:
           )
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
         run: |
           gh api \
-            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}/reactions" \
             -f content=confused

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,147 +2,37 @@ name: AI PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, labeled]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to review"
-        required: false
-      review_mode:
-        description: Review mode
-        required: false
-        default: quick
-        type: choice
-        options: [quick, full]
+    types: [opened, synchronize, ready_for_review]
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   review:
-    permissions:
-      contents: read
-      pull-requests: write
-    concurrency:
-      group: ai-review-${{ github.event.pull_request.number || inputs.pr_number }}
-      cancel-in-progress: true
-    if: >-
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.draft == false &&
-       github.actor != 'dependabot[bot]' &&
-       github.actor != 'renovate[bot]' &&
-       !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') &&
-       (github.event.action != 'labeled' || github.event.label.name == 'ai-review-full'))
+    if: |
+      !github.event.pull_request.draft &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ai-review')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Require pr_number for workflow_dispatch
-        if: github.event_name == 'workflow_dispatch' && inputs.pr_number == ''
-        run: |
-          echo "::error::workflow_dispatch requires pr_number input" >&2
-          exit 1
-
-      - name: Resolve PR refs (workflow_dispatch)
-        id: resolve-pr
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-        run: |
-          base_ref=$(gh pr view "$INPUT_PR_NUMBER" --json baseRefName --jq '.baseRefName')
-          head_sha=$(gh pr view "$INPUT_PR_NUMBER" --json headRefOid --jq '.headRefOid')
-          echo "base_ref=${base_ref}" >> "$GITHUB_OUTPUT"
-          echo "head_sha=${head_sha}" >> "$GITHUB_OUTPUT"
-
-      # Inline the container-action steps because GitHub Actions cannot resolve
-      # action.yml from a private repo when the calling repo is public.
-      - name: Mask credentials
-        env:
-          _API_KEY: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
-          _GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          _REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
-        run: |
-          [[ -n "$_API_KEY" ]]       && echo "::add-mask::$_API_KEY"
-          [[ -n "$_GH_TOKEN" ]]      && echo "::add-mask::$_GH_TOKEN"
-          [[ -n "$_REGISTRY_TOKEN" ]] && echo "::add-mask::$_REGISTRY_TOKEN"
-
-      - name: Log in to GHCR
-        env:
-          REGISTRY_TOKEN: ${{ secrets.GHCR_TOKEN }}
-          REGISTRY_USER: ${{ github.repository_owner }}
-        run: |
-          echo "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_USER" --password-stdin
-
-      - name: Run AI review in container
-        env:
-          IMAGE: ghcr.io/tag1consulting/ai-pr-review:latest
-          AI_PROVIDER: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
-          AI_REVIEW_MODE: >-
-            ${{
-              inputs.review_mode ||
-              (contains(github.event.pull_request.labels.*.name, 'ai-review-full') && 'full') ||
-              'quick'
-            }}
-          FORCE_FULL_DIFF: 'false'
-          REVIEW_TARGET: pr
-          STANDALONE_DEPTH: '50'
-          MAX_DIFF_LINES: '5000'
-          AI_MODEL_STANDARD: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
-          AI_MODEL_PREMIUM: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
-          ANTHROPIC_API_KEY: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
-          BEDROCK_API_KEY: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
-          OPENAI_BASE_URL: ${{ vars.AI_REVIEW_BASE_URL || '' }}
-          BEDROCK_API_URL: ${{ vars.AI_REVIEW_BASE_URL || '' }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          BASE_REF: ${{ steps.resolve-pr.outputs.base_ref || github.event.pull_request.base.ref || github.event.repository.default_branch }}
-          HEAD_SHA: ${{ steps.resolve-pr.outputs.head_sha || github.event.pull_request.head.sha || github.sha }}
-          LLM_RETRY_COUNT: '3'
-          AI_PARALLEL: 'true'
-          AI_CONFIDENCE_THRESHOLD: '75'
-          AI_MAX_INLINE: '25'
-          AI_MAX_TOKENS_PER_AGENT: '8192'
-          AI_ENABLE_SUGGESTIONS: 'true'
-        run: |
-          docker pull "$IMAGE"
-          SUMMARY_MOUNT=()
-          if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-            SUMMARY_MOUNT=(-e GITHUB_STEP_SUMMARY -v "$GITHUB_STEP_SUMMARY:$GITHUB_STEP_SUMMARY")
-          fi
-          docker run --rm \
-            -e AI_PROVIDER \
-            -e AI_REVIEW_MODE \
-            -e FORCE_FULL_DIFF \
-            -e REVIEW_TARGET \
-            -e STANDALONE_DEPTH \
-            -e MAX_DIFF_LINES \
-            -e AI_MODEL_STANDARD \
-            -e AI_MODEL_PREMIUM \
-            -e ANTHROPIC_API_KEY \
-            -e OPENAI_API_KEY \
-            -e GOOGLE_API_KEY \
-            -e BEDROCK_API_KEY \
-            -e OPENAI_BASE_URL \
-            -e BEDROCK_API_URL \
-            -e GH_TOKEN \
-            -e GITHUB_REPOSITORY \
-            -e PR_NUMBER \
-            -e BASE_REF \
-            -e HEAD_SHA \
-            -e LLM_RETRY_COUNT \
-            -e AI_PARALLEL \
-            -e AI_CONFIDENCE_THRESHOLD \
-            -e AI_MAX_INLINE \
-            -e AI_MAX_TOKENS_PER_AGENT \
-            -e AI_ENABLE_SUGGESTIONS \
-            -e GITHUB_WORKSPACE=/workspace \
-            -v "$GITHUB_WORKSPACE:/workspace" \
-            "${SUMMARY_MOUNT[@]}" \
-            "$IMAGE"
+      - name: Run AI review
+        uses: tag1consulting/ai-pr-review/container-action@main
+        with:
+          provider: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
+          api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
+          base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
+          model-standard: ${{ vars.AI_REVIEW_MODEL_STANDARD || '' }}
+          model-premium: ${{ vars.AI_REVIEW_MODEL_PREMIUM || '' }}
+          github-token: ${{ github.token }}
+          pr-number: ${{ github.event.pull_request.number }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          review-mode: 'quick'
+          enable-suggestions: 'true'

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -109,6 +109,7 @@ jobs:
           AI_CONFIDENCE_THRESHOLD: '75'
           AI_MAX_INLINE: '25'
           AI_MAX_TOKENS_PER_AGENT: '8192'
+          AI_ENABLE_SUGGESTIONS: 'true'
         run: |
           docker pull "$IMAGE"
           SUMMARY_MOUNT=()
@@ -140,6 +141,7 @@ jobs:
             -e AI_CONFIDENCE_THRESHOLD \
             -e AI_MAX_INLINE \
             -e AI_MAX_TOKENS_PER_AGENT \
+            -e AI_ENABLE_SUGGESTIONS \
             -e GITHUB_WORKSPACE=/workspace \
             -v "$GITHUB_WORKSPACE:/workspace" \
             "${SUMMARY_MOUNT[@]}" \


### PR DESCRIPTION
## Summary
- Replaces the inlined Docker steps with the `tag1consulting/ai-pr-review/container-action@main` composite action — the ai-pr-review repo is now public, so the workaround for private action resolution is no longer needed
- Adds `ai-review-commands.yml` for slash-command support on PRs: `/ai-pr-review rescan`, `review-full`, `skip`, `help`
- Enables `enable-suggestions` (v0.4.0 feature) across all review invocations — adds GitHub "Apply suggestion" buttons on inline comments
- Drops `workflow_dispatch` and `labeled` triggers in favor of the slash-command workflow, which is more discoverable
- Removes `GHCR_TOKEN` dependency for image pulls (image is now public)

## Test plan
- [ ] Verify the AI review runs automatically on this PR via the container-action
- [ ] Test `/ai-pr-review help` shows command list
- [ ] Test `/ai-pr-review rescan` triggers a full-diff re-review
- [ ] Verify inline comments include "Apply suggestion" buttons