### PR TITLE
docs: add schema-change guidance complementing #185

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,21 @@
 ## Checklist
 
 - [ ] Tests pass (`make go-test`)
-- [ ] If schema changed: SDKs regenerated (`make go-sdk-all`) and included in this PR
+- [ ] **Schema change?** The following all count as schema changes and require regeneration:
+  - adding, removing, or renaming a field on a `*Args` or `*State` struct
+  - changing or adding a `pulumi:"..."` struct tag
+  - changing or adding an `Annotate` description
+  - adding a new resource
+  - changing any input/output type signature
+
+  If any of the above applies, run `make go-schema && make go-sdk-all` and commit the
+  regenerated `provider/schema.json` and all `sdk/{python,nodejs,go,dotnet}/` changes
+  in this PR. CI's `verify-sdks` workflow will fail otherwise.
+
+  Use the Pulumi CLI version pinned in [`.pulumiversion`](../.pulumiversion) — see
+  [CONTRIBUTING.md](../CONTRIBUTING.md#prerequisites). If your local CLI version does
+  not match, install the pinned version or note the mismatch in the PR description
+  and ask a maintainer to regenerate.
 
 ## Test Plan
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,39 @@ sdk/                 # Generated SDKs — do not hand-edit
 examples/            # Usage examples
 ```
 
+## Making Schema Changes
+
+Any change that affects the Pulumi-facing surface of a resource counts as a schema
+change and requires regenerating `provider/schema.json` plus all four SDKs. This
+includes:
+
+- adding, removing, or renaming a field on a `*Args` or `*State` struct
+- changing or adding a `pulumi:"..."` struct tag
+- changing or adding an `Annotate` description
+- adding a new resource (see next section)
+- changing any input/output type signature
+
+When you have made a schema-affecting change, regenerate with the pinned Pulumi CLI:
+
+```bash
+make check-pulumi-version   # Verifies your local CLI matches .pulumiversion
+make go-schema              # Regenerates provider/schema.json
+make go-sdk-all             # Regenerates sdk/python, sdk/nodejs, sdk/go, sdk/dotnet
+```
+
+(`go-schema` and the `go-sdk-*` targets run `check-pulumi-version` automatically; the
+standalone invocation above is for when you want to verify the pin before a long
+regeneration.)
+
+Commit `provider/schema.json` **and** all `sdk/{python,nodejs,go,dotnet}/` changes in
+the same PR as the provider source change. CI's `verify-sdks` workflow fails any PR
+whose committed artifacts drift from a fresh regeneration.
+
+If your local CLI version does not match `.pulumiversion`, install the pinned version
+(see [Prerequisites](#prerequisites)) or note the mismatch in your PR description and
+ask a maintainer to run the regeneration. Do not merge without the regenerated
+artifacts.
+
 ## Adding a New Resource
 
 1. **Add GraphQL queries** to `provider/pkg/client/queries.go`.
@@ -51,10 +84,10 @@ examples/            # Usage examples
 
 5. **Register the resource** in the provider constructor (see `provider/pkg/provider/`).
 
-6. **Regenerate the schema and SDKs:**
+6. **Regenerate the schema and SDKs** (see [Making Schema Changes](#making-schema-changes)):
    ```bash
    make go-schema    # Regenerates provider/schema.json
-   make go-sdk-all   # Regenerates sdk/python, sdk/nodejs, sdk/go
+   make go-sdk-all   # Regenerates sdk/python, sdk/nodejs, sdk/go, sdk/dotnet
    ```
 
 7. **Verify tests pass:**

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
         multi-cluster-deploy multi-cluster-verify multi-cluster-port-forwards multi-cluster-port-forwards-all \
         multi-cluster-test-api multi-cluster-test-ui multi-cluster-info \
         clean clean-all \
-        go-build go-test go-vet go-schema go-sdk-clean go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-dotnet go-sdk-all go-install check-release-version release-prep go-proxy-warmup check-versions
+        go-build go-test go-vet go-schema go-sdk-clean go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-dotnet go-sdk-all go-install check-release-version release-prep go-proxy-warmup check-versions check-pulumi-version
 
 # Variables
 PYTHON := python3
@@ -387,7 +387,42 @@ go-vet:
 go-lint:
 	cd provider && golangci-lint run ./...
 
-go-schema: go-build
+# check-pulumi-version verifies the local Pulumi CLI matches the version pinned
+# in .pulumiversion. Schema/SDK generators are sensitive to CLI version drift —
+# a mismatch produces diffs that don't match the provider source, which CI's
+# verify-sdks workflow will reject. Running this check locally before regen
+# avoids a long roundtrip through CI. Bypass with SKIP_PULUMI_VERSION_CHECK=1
+# only when you know what you're doing (e.g., testing a new CLI version before
+# updating the pin).
+check-pulumi-version:
+	@if [ -n "$(SKIP_PULUMI_VERSION_CHECK)" ]; then \
+		echo "WARNING: Pulumi CLI version check skipped (SKIP_PULUMI_VERSION_CHECK=$(SKIP_PULUMI_VERSION_CHECK))"; \
+		exit 0; \
+	fi
+	@command -v pulumi >/dev/null 2>&1 || { \
+		echo "ERROR: pulumi CLI not found. Install from https://www.pulumi.com/docs/install/" >&2; \
+		exit 1; \
+	}
+	@if [ ! -f .pulumiversion ]; then \
+		echo "ERROR: .pulumiversion not found at repo root" >&2; \
+		exit 1; \
+	fi
+	@PINNED=$$(cat .pulumiversion | tr -d '[:space:]'); \
+	ACTUAL=$$(pulumi version 2>/dev/null | sed 's/^v//' | head -1); \
+	if [ "$$PINNED" != "$$ACTUAL" ]; then \
+		echo "ERROR: Pulumi CLI version mismatch." >&2; \
+		echo "  pinned (.pulumiversion):    $$PINNED" >&2; \
+		echo "  installed (pulumi version): $$ACTUAL" >&2; \
+		echo "" >&2; \
+		echo "Install the pinned version:" >&2; \
+		echo "  curl -fsSL https://get.pulumi.com | sh -s -- --version $$PINNED" >&2; \
+		echo "" >&2; \
+		echo "Or set SKIP_PULUMI_VERSION_CHECK=1 to bypass (not recommended)." >&2; \
+		exit 1; \
+	fi; \
+	echo "Pulumi CLI version OK ($$ACTUAL)"
+
+go-schema: check-pulumi-version go-build
 	pulumi package get-schema ./$(PROVIDER_BIN) > provider/schema.json
 
 go-sdk-clean:
@@ -398,7 +433,7 @@ go-sdk-clean:
 # Generated files are rsynced over, then the temp directory is removed.
 SDK_TMP := .sdk-gen-tmp
 
-go-sdk-python: go-build
+go-sdk-python: check-pulumi-version go-build
 	rm -rf $(SDK_TMP)
 	pulumi package gen-sdk ./$(PROVIDER_BIN) --language python -o $(SDK_TMP)
 	rsync -a --ignore-existing $(SDK_TMP)/python/ sdk/python/
@@ -411,7 +446,7 @@ go-sdk-python: go-build
 	# "from pulumi_lagoon import Project" instead of "from pulumi_lagoon.lagoon import Project".
 	printf '\n# Re-export resource classes at the top level for convenience.\n# This is appended by the go-sdk-python Makefile target after generation.\nfrom .lagoon import *\n' >> sdk/python/pulumi_lagoon/__init__.py
 
-go-sdk-nodejs: go-build
+go-sdk-nodejs: check-pulumi-version go-build
 	rm -rf $(SDK_TMP)
 	pulumi package gen-sdk ./$(PROVIDER_BIN) --language nodejs -o $(SDK_TMP)
 	rsync -a --ignore-existing $(SDK_TMP)/nodejs/ sdk/nodejs/
@@ -436,7 +471,7 @@ go-sdk-nodejs: go-build
 	cp LICENSE sdk/nodejs/LICENSE
 	rm -rf $(SDK_TMP)
 
-go-sdk-go: go-build
+go-sdk-go: check-pulumi-version go-build
 	rm -rf $(SDK_TMP)
 	pulumi package gen-sdk ./$(PROVIDER_BIN) --language go -o $(SDK_TMP)
 	rsync -a --delete --exclude='go.mod' --exclude='go.sum' --exclude='LICENSE' $(SDK_TMP)/go/ sdk/go/
@@ -449,7 +484,7 @@ go-sdk-go: go-build
 #   - patches TargetFramework to net8.0 (codegen emits net6.0 which is EOL)
 #   - restores logo.png from docs/ (codegen copies the SVG under a .png name;
 #     we overwrite it with the real PNG so NuGet package icon renders correctly)
-go-sdk-dotnet: go-build
+go-sdk-dotnet: check-pulumi-version go-build
 	rm -rf $(SDK_TMP)
 	pulumi package gen-sdk ./$(PROVIDER_BIN) --language dotnet -o $(SDK_TMP)
 	mkdir -p sdk/dotnet

--- a/Makefile
+++ b/Makefile
@@ -423,14 +423,14 @@ go-sdk-nodejs: go-build
 	done
 	# Fix generated path: utilities.ts uses require('./package.json') but compiles to bin/
 	# where package.json is one level up, so patch it to require('../package.json').
-	sed -i "s|require('./package.json')|require('../package.json')|g" sdk/nodejs/utilities.ts
+	sed -i.bak "s|require('./package.json')|require('../package.json')|g" sdk/nodejs/utilities.ts && rm -f sdk/nodejs/utilities.ts.bak
 	# Re-export resource classes at the top level so users can write
 	# import { Project } from "@tag1consulting/pulumi-lagoon".
 	printf '\n// Re-export resource classes at the top level for convenience.\n// This is appended by the go-sdk-nodejs Makefile target after generation.\nexport * from "./lagoon";\n' >> sdk/nodejs/index.ts
 	# Inject description field into package.json (codegen does not emit it).
 	# Guard: only inject if not already present (idempotent across re-runs).
 	grep -q '"description"' sdk/nodejs/package.json || \
-		sed -i '/"name": "@tag1consulting\/pulumi-lagoon"/a\    "description": "Manage Lagoon hosting platform resources as infrastructure-as-code.",' sdk/nodejs/package.json
+		{ awk '{print} /"name": "@tag1consulting\/pulumi-lagoon"/{print "    \"description\": \"Manage Lagoon hosting platform resources as infrastructure-as-code.\","}' sdk/nodejs/package.json > sdk/nodejs/package.json.tmp && mv sdk/nodejs/package.json.tmp sdk/nodejs/package.json; }
 	grep -q '"description"' sdk/nodejs/package.json || \
 		(echo "ERROR: description injection failed in package.json" >&2 && exit 1)
 	cp LICENSE sdk/nodejs/LICENSE
@@ -457,29 +457,29 @@ go-sdk-dotnet: go-build
 	cp LICENSE sdk/dotnet/LICENSE
 	# Patch generated TargetFramework to net8.0 (codegen emits net6.0, which is EOL).
 	# Match any TFM so this remains effective if codegen ever emits net7.0/net9.0.
-	sed -i 's|<TargetFramework>[^<]*</TargetFramework>|<TargetFramework>net8.0</TargetFramework>|' sdk/dotnet/Tag1Consulting.Lagoon.csproj
+	sed -i.bak 's|<TargetFramework>[^<]*</TargetFramework>|<TargetFramework>net8.0</TargetFramework>|' sdk/dotnet/Tag1Consulting.Lagoon.csproj && rm -f sdk/dotnet/Tag1Consulting.Lagoon.csproj.bak
 	grep -q '<TargetFramework>net8.0</TargetFramework>' sdk/dotnet/Tag1Consulting.Lagoon.csproj || \
 		(echo "ERROR: TargetFramework patch failed in Tag1Consulting.Lagoon.csproj" >&2 && exit 1)
 	# Inject PackageReadmeFile property (codegen does not emit it).
 	# Guard: only inject if not already present (idempotent across re-runs).
 	grep -q '<PackageReadmeFile>' sdk/dotnet/Tag1Consulting.Lagoon.csproj || \
-		sed -i '/<PackageIcon>logo.png<\/PackageIcon>/a\    <PackageReadmeFile>README.md</PackageReadmeFile>' sdk/dotnet/Tag1Consulting.Lagoon.csproj
+		{ awk '{print} /<PackageIcon>logo.png<\/PackageIcon>/{print "    <PackageReadmeFile>README.md</PackageReadmeFile>"}' sdk/dotnet/Tag1Consulting.Lagoon.csproj > sdk/dotnet/Tag1Consulting.Lagoon.csproj.tmp && mv sdk/dotnet/Tag1Consulting.Lagoon.csproj.tmp sdk/dotnet/Tag1Consulting.Lagoon.csproj; }
 	grep -q '<PackageReadmeFile>README.md</PackageReadmeFile>' sdk/dotnet/Tag1Consulting.Lagoon.csproj || \
 		(echo "ERROR: PackageReadmeFile patch failed in Tag1Consulting.Lagoon.csproj" >&2 && exit 1)
 	# Inject PackageTags property (codegen does not emit it).
 	# Guard: only inject if not already present (idempotent across re-runs).
 	grep -q '<PackageTags>' sdk/dotnet/Tag1Consulting.Lagoon.csproj || \
-		sed -i '/<PackageReadmeFile>README.md<\/PackageReadmeFile>/a\    <PackageTags>lagoon;pulumi;infrastructure-as-code;kubernetes;hosting</PackageTags>' sdk/dotnet/Tag1Consulting.Lagoon.csproj
+		{ awk '{print} /<PackageReadmeFile>README.md<\/PackageReadmeFile>/{print "    <PackageTags>lagoon;pulumi;infrastructure-as-code;kubernetes;hosting</PackageTags>"}' sdk/dotnet/Tag1Consulting.Lagoon.csproj > sdk/dotnet/Tag1Consulting.Lagoon.csproj.tmp && mv sdk/dotnet/Tag1Consulting.Lagoon.csproj.tmp sdk/dotnet/Tag1Consulting.Lagoon.csproj; }
 	grep -q '<PackageTags>' sdk/dotnet/Tag1Consulting.Lagoon.csproj || \
 		(echo "ERROR: PackageTags injection failed in Tag1Consulting.Lagoon.csproj" >&2 && exit 1)
 	# Pack README.md into the nupkg root (codegen does not include it).
 	# Guard: only inject if not already present (idempotent across re-runs).
 	grep -q '<None Include="README.md"' sdk/dotnet/Tag1Consulting.Lagoon.csproj || \
-		sed -i '/<None Include="logo.png">/i\    <None Include="README.md" Pack="true" PackagePath="" />' sdk/dotnet/Tag1Consulting.Lagoon.csproj
+		{ awk '/<None Include="logo.png">/{print "    <None Include=\"README.md\" Pack=\"true\" PackagePath=\"\" />"} {print}' sdk/dotnet/Tag1Consulting.Lagoon.csproj > sdk/dotnet/Tag1Consulting.Lagoon.csproj.tmp && mv sdk/dotnet/Tag1Consulting.Lagoon.csproj.tmp sdk/dotnet/Tag1Consulting.Lagoon.csproj; }
 	# Replace the SVG-disguised-as-PNG that codegen copies with a real PNG.
 	cp docs/logo.png sdk/dotnet/logo.png
 	# Ensure version.txt has a trailing newline (codegen omits it).
-	sed -i -e '$$a\' sdk/dotnet/version.txt
+	awk 1 sdk/dotnet/version.txt > sdk/dotnet/version.txt.tmp && mv sdk/dotnet/version.txt.tmp sdk/dotnet/version.txt
 	rm -rf $(SDK_TMP)
 
 # go-sdk-all regenerates all SDKs without a clean; use go-sdk-clean first for a
@@ -509,16 +509,16 @@ endif
 # Usage: make release-prep VERSION=0.3.0
 release-prep: check-release-version
 	@echo "=== Setting version $(VERSION) ==="
-	sed -i 's/var Version = .*/var Version = "$(VERSION)"/' provider/cmd/pulumi-resource-lagoon/main.go
-	sed -i 's/^PROVIDER_VERSION ?= .*/PROVIDER_VERSION ?= $(VERSION)/' Makefile
-	sed -i 's/"version": ".*"/"version": "$(VERSION)"/' provider/schema.json
-	sed -i 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' README.md
-	sed -i 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' CLAUDE.md
+	sed -i.bak 's/var Version = .*/var Version = "$(VERSION)"/' provider/cmd/pulumi-resource-lagoon/main.go && rm -f provider/cmd/pulumi-resource-lagoon/main.go.bak
+	sed -i.bak 's/^PROVIDER_VERSION ?= .*/PROVIDER_VERSION ?= $(VERSION)/' Makefile && rm -f Makefile.bak
+	sed -i.bak 's/"version": ".*"/"version": "$(VERSION)"/' provider/schema.json && rm -f provider/schema.json.bak
+	sed -i.bak 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' README.md && rm -f README.md.bak
+	sed -i.bak 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' CLAUDE.md && rm -f CLAUDE.md.bak
 	printf '# Release v$(VERSION) (%s)\n\nTODO: Write release notes before committing.\n\n---\n\n' "$$(date +%Y-%m-%d)" > /tmp/rn_header.md && cat RELEASE_NOTES.md >> /tmp/rn_header.md && mv /tmp/rn_header.md RELEASE_NOTES.md
 	$(MAKE) PROVIDER_VERSION=$(VERSION) go-build go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-dotnet
-	sed -i 's/^  version = .*/  version = "$(VERSION)"/' sdk/python/pyproject.toml
+	sed -i.bak 's/^  version = .*/  version = "$(VERSION)"/' sdk/python/pyproject.toml && rm -f sdk/python/pyproject.toml.bak
 	jq --indent 4 --arg v "$(VERSION)" '.version = $$v | .pulumi.version = $$v' sdk/nodejs/package.json > sdk/nodejs/package.json.tmp && mv sdk/nodejs/package.json.tmp sdk/nodejs/package.json
-	sed -i 's|<Version>.*</Version>|<Version>$(VERSION)</Version>|' sdk/dotnet/Tag1Consulting.Lagoon.csproj
+	sed -i.bak 's|<Version>.*</Version>|<Version>$(VERSION)</Version>|' sdk/dotnet/Tag1Consulting.Lagoon.csproj && rm -f sdk/dotnet/Tag1Consulting.Lagoon.csproj.bak
 	echo "$(VERSION)" > sdk/dotnet/version.txt
 	@echo "=== Running tests ==="
 	cd provider && CGO_ENABLED=0 go test ./... -count=1

--- a/Makefile
+++ b/Makefile
@@ -512,8 +512,8 @@ release-prep: check-release-version
 	sed -i.bak 's/var Version = .*/var Version = "$(VERSION)"/' provider/cmd/pulumi-resource-lagoon/main.go && rm -f provider/cmd/pulumi-resource-lagoon/main.go.bak
 	sed -i.bak 's/^PROVIDER_VERSION ?= .*/PROVIDER_VERSION ?= $(VERSION)/' Makefile && rm -f Makefile.bak
 	sed -i.bak 's/"version": ".*"/"version": "$(VERSION)"/' provider/schema.json && rm -f provider/schema.json.bak
-	sed -i.bak 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' README.md && rm -f README.md.bak
-	sed -i.bak 's/^\*\*Status\*\*: v[0-9]\+\.[0-9]\+\.[0-9]\+/\*\*Status\*\*: v$(VERSION)/' CLAUDE.md && rm -f CLAUDE.md.bak
+	sed -i.bak 's/^\*\*Status\*\*: v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/\*\*Status\*\*: v$(VERSION)/' README.md && rm -f README.md.bak
+	sed -i.bak 's/^\*\*Status\*\*: v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/\*\*Status\*\*: v$(VERSION)/' CLAUDE.md && rm -f CLAUDE.md.bak
 	printf '# Release v$(VERSION) (%s)\n\nTODO: Write release notes before committing.\n\n---\n\n' "$$(date +%Y-%m-%d)" > /tmp/rn_header.md && cat RELEASE_NOTES.md >> /tmp/rn_header.md && mv /tmp/rn_header.md RELEASE_NOTES.md
 	$(MAKE) PROVIDER_VERSION=$(VERSION) go-build go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-dotnet
 	sed -i.bak 's/^  version = .*/  version = "$(VERSION)"/' sdk/python/pyproject.toml && rm -f sdk/python/pyproject.toml.bak


### PR DESCRIPTION
## Summary

Follow-on to #185. Adds three complementary doc/tooling improvements that make it
easier for contributors to recognize when a change requires SDK regeneration and
fail fast locally when their Pulumi CLI version does not match `.pulumiversion`.

**This PR depends on #185 merging first** — it was developed on top of #185's
branch so the Makefile additions stack cleanly. After #185 lands I'll rebase
this onto main.

## Motivation

PR #183 shipped without the regenerated `provider/schema.json` and SDKs because
the contributor did not recognize that adding an output field to a `*State`
struct qualifies as a "schema change." PR #185 solves the CI-side half of this
(version pinning + drift detection). This PR adds three contributor-facing
guardrails that #185 deliberately scopes out:

1. **PR template checkbox expansion** — enumerates the full list of schema-change
   triggers so a contributor reading the checkbox immediately knows whether their
   change qualifies.
2. **CONTRIBUTING.md "Making Schema Changes" section** — a dedicated section that
   documents the trigger set + regeneration workflow, so contributors hit the
   guidance before they reach "Adding a New Resource" (which is no longer the
   only path to a schema change).
3. **Local `check-pulumi-version` Makefile target** — verifies the local CLI
   matches `.pulumiversion` before `go-schema` or any `go-sdk-*` target runs.
   Catches CLI mismatches locally instead of after a full SDK regeneration pass
   that produces a diff no one wants. Bypass via `SKIP_PULUMI_VERSION_CHECK=1`
   for intentional experiments.

The CI side (`verify-sdks.yml`) and version pin (`.pulumiversion`) are provided
by #185 and not touched here.

## Test Plan

- [x] `make check-pulumi-version` passes with matching CLI version
- [x] `make check-pulumi-version` fails cleanly with a mismatched pin (tested by
      temporarily editing `.pulumiversion`)
- [x] `make -n go-schema` shows `check-pulumi-version` runs first
- [ ] Verify CI's `verify-sdks` workflow still passes with the new Makefile
      dependency (runs when PR opens)