### PR TITLE
Fix documentation site links and follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A Pulumi provider for managing [Lagoon](https://www.lagoon.sh/) resources as infrastructure-as-code.
 
-**[Documentation Site](https://tag1consulting.github.io/pulumi-lagoon-provider/)** | **[Getting Started](https://tag1consulting.github.io/pulumi-lagoon-provider/getting-started/)** | **[Resource Reference](https://tag1consulting.github.io/pulumi-lagoon-provider/resources/)**
+**[Documentation Site](https://tag1consulting.github.io/pulumi-lagoon-provider/)** | **[Getting Started](https://tag1consulting.github.io/pulumi-lagoon-provider/getting-started.html)** | **[Resource Reference](https://tag1consulting.github.io/pulumi-lagoon-provider/resources.html)**
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Follow-up fixes for the documentation site (PR #191).

- Fix broken Getting Started and Resource Reference links in README.md (missing `.html` extension)

## Test plan

- [ ] Verify README links resolve correctly on the live site