### PR TITLE
ci: wire Epic 3 inputs + dev image to ai-pr-review

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Run AI review
         uses: tag1consulting/ai-pr-review/container-action@main
         with:
+          # vars.AI_REVIEW_IMAGE_TAG pins the container image (default 'latest';
+          # this repo dogfoods 'dev' ahead of the Epic 4 default-engine flip).
+          image-tag: ${{ vars.AI_REVIEW_IMAGE_TAG || 'latest' }}
           provider: ${{ vars.AI_REVIEW_PROVIDER || 'bedrock-proxy' }}
           api-key: ${{ secrets.AI_REVIEW_API_KEY || secrets.TAG1_BEDROCK_API_KEY }}
           base-url: ${{ vars.AI_REVIEW_BASE_URL || '' }}
@@ -40,3 +43,16 @@ jobs:
           head-sha: ${{ github.event.pull_request.head.sha }}
           review-mode: 'quick'
           enable-suggestions: 'true'
+          # vars.AI_PR_REVIEW_ENGINE selects the compute engine (default 'bash';
+          # the Epic 3 capabilities below require 'python').
+          engine: ${{ vars.AI_PR_REVIEW_ENGINE || 'bash' }}
+          # vars.AI_REVIEW_IGNORE_MERGE_COMMITS strips upstream base-branch
+          # merge commits before diffing (default false).
+          ignore-merge-commits: ${{ vars.AI_REVIEW_IGNORE_MERGE_COMMITS || 'false' }}
+          # --- Epic 3: opt-in capabilities (Python engine only) ---
+          # vars.AI_REVIEW_CONTEXT_ENRICHMENT injects tree-sitter symbol
+          # context into agent prompts (default false).
+          context-enrichment: ${{ vars.AI_REVIEW_CONTEXT_ENRICHMENT || 'false' }}
+          # vars.AI_REVIEW_FEEDBACK_LOOP loads recent /ai-pr-review feedback
+          # entries from the ai-pr-review-bot branch (default false).
+          feedback-loop: ${{ vars.AI_REVIEW_FEEDBACK_LOOP || 'false' }}


### PR DESCRIPTION
## Summary

Wires five new repo-variable-backed inputs into the AI PR Review workflow so this repo can pick up the Epic 3 capabilities and the dev container image.

All five default to off (or to the consumer defaults), so behavior is unchanged unless the corresponding repo variable is set. Repo vars on this project are already set to the values below.

| Input | Reads | Currently set to |
|-------|-------|------------------|
| `image-tag` | `vars.AI_REVIEW_IMAGE_TAG` | `dev` |
| `engine` | `vars.AI_PR_REVIEW_ENGINE` | `python` |
| `ignore-merge-commits` | `vars.AI_REVIEW_IGNORE_MERGE_COMMITS` | `true` |
| `context-enrichment` | `vars.AI_REVIEW_CONTEXT_ENRICHMENT` | `true` (Capability A) |
| `feedback-loop` | `vars.AI_REVIEW_FEEDBACK_LOOP` | `true` (Capability C) |

## Why

Part of the Epic 3 / Epic 4 dogfooding rollout — Epic 3 (`tag1consulting/ai-pr-review#197`, shipped via PR #286) introduced three opt-in capabilities behind feature flags. Enabling them on internal repos with real PR traffic feeds the Epic 4 soak window before the default engine flips from `bash` to `python`.

## Test plan

- [x] Default behavior unchanged when vars are unset (all inputs fall back to their existing defaults).
- [ ] On merge: the next PR review on this repo runs against `ghcr.io/tag1consulting/ai-pr-review:dev` with the Python engine and the three opt-in capabilities active.