### PR TITLE
ci: scope pages.yml permissions to the jobs that need them

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,11 +8,6 @@ on:
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -20,6 +15,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -49,6 +46,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Tightens the GitHub Pages deploy workflow to least-privilege by moving the workflow-level `permissions` block down to per-job scopes.

| Job | Before (inherited workflow-level) | After (job-scoped) |
|-----|-----------------------------------|--------------------|
| `build` | `contents: read`, `pages: write`, `id-token: write` | `contents: read` |
| `deploy` | `contents: read`, `pages: write`, `id-token: write` | `pages: write`, `id-token: write` |

The build job only checks out code and runs Jekyll, so it never needs `pages: write` or `id-token: write`. Only the deploy job (`actions/deploy-pages@v5`) needs those — `pages: write` to create the deployment and `id-token: write` for the OIDC verification token (confirmed against the `actions/deploy-pages` docs). This matches the job-scoped permission pattern already used by the other workflows in this repo.

## Background

Surfaced as a defense-in-depth finding during the v0.5.1 pre-release review. It's a minor hardening item (the original matched GitHub's own Jekyll starter template), addressed now as a standalone follow-up.

## Risk / verification

- Functionally equivalent on the happy path — the deploy job still receives exactly the scopes `deploy-pages@v5` requires.
- No untrusted-input interpolation introduced; the only `${{ }}` expression (`steps.pages.outputs.base_path`) comes from `actions/configure-pages` reading GitHub-controlled repo metadata, not PR content.
- YAML validated.
- The real test is the next push to `main` touching `site/**` — the Pages deploy should still succeed with the narrower deploy-job scopes.