### PR TITLE
ci(security): gate ai-review.yml on author_association (HIGH, #222)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,8 +1,20 @@
 name: AI PR Review
 
 # pull_request_target runs the workflow from the base branch so that secrets
-# and repo variables are available even for fork PRs.  This is safe because the
-# AI review action only *reads* the checked-out code — it never executes it.
+# and repo variables are available even for fork PRs. This is safe only as
+# long as the AI review action treats the checked-out code as untrusted data
+# and never executes it. That guarantee is documented as an explicit invariant
+# of tag1consulting/ai-pr-review (SECURITY.md → "Security invariants").
+#
+# Defense-in-depth: this workflow additionally gates on author_association
+# (OWNER/MEMBER/COLLABORATOR), so a fork PR from an arbitrary actor will not
+# trigger a secret-bearing run even if the action invariant ever regressed.
+# Mirror of the gate already used by ai-review-commands.yml for slash commands.
+#
+# Note: tag1consulting/ai-pr-review/container-action@main is intentionally a
+# mutable ref. This is a dogfooding/canary repo and we own the action; the
+# mutable-ref supply-chain risk is accepted, with the action invariant above
+# as the load-bearing mitigation.
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
@@ -18,7 +30,8 @@ jobs:
       !github.event.pull_request.draft &&
       github.actor != 'dependabot[bot]' &&
       github.actor != 'renovate[bot]' &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-ai-review')
+      !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Mirror the OWNER/MEMBER/COLLABORATOR gate that `ai-review-commands.yml` already uses, so a fork PR from an arbitrary actor cannot trigger a secret-bearing run via `pull_request_target`.

The header comment is updated to record both controls and the deliberate accepted-risk on `container-action@main`.

Fixes #222.

## What changed

`.github/workflows/ai-review.yml`:

- Added an `author_association` check to the existing job-level `if:` so only OWNER/MEMBER/COLLABORATOR PRs trigger the secret-bearing review job.
- Rewrote the header comment to document the safety model: the load-bearing control is the action's "never execute checked-out code" invariant; this workflow's gate is defense-in-depth.

## Threat model after this change

| Layer | Control |
|---|---|
| 1 (load-bearing) | tag1consulting/ai-pr-review treats `\$GITHUB_WORKSPACE` as untrusted data (documented invariant in [ai-pr-review SECURITY.md](https://github.com/tag1consulting/ai-pr-review/blob/main/SECURITY.md#security-invariants), tag1consulting/ai-pr-review#491) |
| 2 (this PR) | `author_association in {OWNER, MEMBER, COLLABORATOR}` — fork PRs from arbitrary actors never get secrets |
| 3 (existing) | Draft PRs, dependabot/renovate, and skip-label PRs are excluded |
| 4 (existing) | `permissions:` is restricted to `contents: read`, `issues: write`, `pull-requests: write` (no `contents: write`) |

A fork PR from a contributor without write access will simply not trigger the workflow. They can still use the `/ai-review` slash command path, which is gated by the same `author_association` check on the **commenter** in `ai-review-commands.yml` — i.e., a maintainer can opt the PR in, the same way it works on other Tag1 repos.

## Accepted risk: container-action@main

This repo continues to reference `tag1consulting/ai-pr-review/container-action@main` (a mutable ref) for dogfooding/canary purposes. The mutable-ref supply-chain risk is an explicit, documented decision (see header comment). The action's invariant is the load-bearing mitigation; if that invariant ever regresses, the canary nature of this repo means we'd see it here first.

## Rejected alternative

Splitting into the textbook two-workflow pattern (`pull_request` artifact producer → `pull_request_target`/`workflow_run` consumer). Rejected because (a) it is a significant restructure of how this repo dogfoods the action; (b) the action invariant + `author_association` gate already closes the practical attack path; (c) the slash-command path in `ai-review-commands.yml` already uses the same single-job pattern and would need parallel restructuring. Worth doing if the action invariant ever has to be relaxed; not now.

## Test plan

- [ ] Workflow YAML parses without lint errors (`gh workflow view ai-review.yml` after merge)
- [ ] An internal maintainer's PR (this one) still triggers a review run successfully
- [ ] Confirm via the next external-contributor PR that the gate excludes them (or simulate locally with `act -e` if desired)