### PR TITLE
ci(security): SHA-pin release-critical third-party actions (#223)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v7
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d  # v7.0.0
         with:
           pulumi-version: ${{ steps.pulumi-version.outputs.version }}
 
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-path: provider/go.sum
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89  # v7.2.2
         with:
           args: release --clean
           version: '~> 2'
@@ -260,7 +260,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -282,7 +282,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
 
   publish-npm:
     name: Publish to npm
@@ -423,7 +423,7 @@ jobs:
           path: dist/
 
       - name: NuGet login (OIDC trusted publishing)
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841  # v1.2.0
         id: nuget_login
         with:
           user: gchaix

--- a/.github/workflows/verify-sdks.yml
+++ b/.github/workflows/verify-sdks.yml
@@ -28,7 +28,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install Pulumi CLI
-        uses: pulumi/actions@v7
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d  # v7.0.0
         with:
           pulumi-version: ${{ steps.pulumi-version.outputs.version }}
 


### PR DESCRIPTION
## Summary

Pin the four release-critical third-party actions to immutable commit SHAs with version comments. These actions run during release with package-publishing capability and OIDC `id-token: write`, so a tag-move or branch compromise upstream could tamper with published artifacts. Renovate manages SHA bumps via the existing tag1consulting renovate-config.

Fixes #223.

## Pins

| Action | Old | New | Release |
|---|---|---|---|
| pypa/gh-action-pypi-publish | \`@release/v1\` | \`@cef221092ed1bacb1cc03d23a2d87d1d172e277b\` | v1.14.0 |
| goreleaser/goreleaser-action | \`@v7\` | \`@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89\` | v7.2.2 |
| pulumi/actions | \`@v7\` | \`@8e5e406f4007fca908480587cb9893c07090f58d\` | v7.0.0 |
| NuGet/login | \`@v1\` | \`@8d196754b4036150537f80ac539e15c2f1028841\` | v1.2.0 |

SHAs resolved via \`gh api repos/<repo>/git/ref/{heads,tags}/<ref>\` against the upstream refs at the time of this PR.

## Out of scope

By documented policy and explicit accepted-risk decisions:

- **actions/* major-version floats** (\`actions/checkout@v6\`, \`actions/setup-go@v6\`, etc.) remain. The patch-receiving policy is documented at [agents/security-reviewer.md L102 in claude-comprehensive-review](https://github.com/tag1consulting/claude-comprehensive-review/blob/main/agents/security-reviewer.md).
- **tag1consulting/ai-pr-review/container-action@main** remains on \`@main\` (dogfooding/canary, self-owned). Mitigated by the action's documented "never execute checked-out code" invariant (tag1consulting/ai-pr-review#491, [SECURITY.md → Security invariants](https://github.com/tag1consulting/ai-pr-review/blob/main/SECURITY.md)).
- **ruby/setup-ruby** (pages.yml) and **golangci/golangci-lint-action** (test-go.yml) are not release-critical (Pages docs build and lint job; no \`id-token: write\` against a registry). Worth pinning eventually, but separate from the release-path hardening this PR addresses.

## Test plan

- [ ] Workflows parse without YAML errors after merge
- [ ] Next release (vX.Y.Z) successfully runs publish.yml end to end:
  - [ ] PyPI publish (TestPyPI step + PyPI step)
  - [ ] goreleaser job uploads provider binaries
  - [ ] NuGet OIDC login + publish step
  - [ ] Pulumi CLI install step in both publish.yml and verify-sdks.yml
- [ ] Renovate opens a SHA-bump PR for one of the pinned actions within ~1 week (sanity check that bumps still flow)