### PR TITLE
fix(scripts): verify TLS by default for non-localhost Keycloak (#224)

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -161,8 +161,9 @@ get_secret_value() {
 curl_insecure_for_url() {
     local url="$1"
     local host
-    # Strip scheme, then take everything before the next /, :, or end
-    host=$(echo "$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' | sed -E 's#[/:?#].*$##')
+    # Strip scheme and any userinfo (user[:pass]@), then take everything
+    # before the next /, :, ?, #, or end of string.
+    host=$(echo "$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://([^@/]*@)?##' | sed -E 's#[/:?#].*$##')
     case "$host" in
         localhost|127.0.0.1|::1)
             echo "-k"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -147,6 +147,36 @@ get_secret_value() {
         -o jsonpath="{.data.$key}" 2>/dev/null | base64 -d 2>/dev/null
 }
 
+# Emit '-k' (disable TLS verification) for curl ONLY when the target URL is
+# local (http to localhost / 127.0.0.1) or the caller has explicitly opted in
+# via LAGOON_INSECURE_TLS=1. Used by dev tooling that talks to dev Keycloak
+# (kind cluster, port-forwards, self-signed nip.io endpoints).
+#
+# Usage:
+#   curl -s $(curl_insecure_for_url "$URL") -X POST "$URL" ...
+#
+# For localhost/127.0.0.1 targets, prints "-k" (TLS verification is moot for
+# the loopback case but harmless; matches prior behavior). For any other
+# target, prints nothing unless LAGOON_INSECURE_TLS=1 is set.
+curl_insecure_for_url() {
+    local url="$1"
+    local host
+    # Strip scheme, then take everything before the next /, :, or end
+    host=$(echo "$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' | sed -E 's#[/:?#].*$##')
+    case "$host" in
+        localhost|127.0.0.1|::1)
+            echo "-k"
+            ;;
+        *)
+            if [ "${LAGOON_INSECURE_TLS:-}" = "1" ]; then
+                log_warn "LAGOON_INSECURE_TLS=1: disabling TLS verification for $host" >&2
+                echo "-k"
+            fi
+            # Verify by default for non-localhost URLs
+            ;;
+    esac
+}
+
 # Print current configuration (for debugging)
 print_config() {
     echo "Current configuration:"

--- a/scripts/get-token.sh
+++ b/scripts/get-token.sh
@@ -9,10 +9,13 @@
 # See scripts/common.sh for configuration options.
 #
 # Additional configuration:
-#   KEYCLOAK_URL      - Keycloak base URL (default: http://localhost:8080)
-#   LAGOON_USERNAME   - Lagoon admin username (default: lagoonadmin)
-#   LAGOON_PASSWORD   - Lagoon admin password (fetched from secret if not set)
-#   CLIENT_ID         - Keycloak client ID (default: lagoon-ui)
+#   KEYCLOAK_URL         - Keycloak base URL (default: http://localhost:8080)
+#   LAGOON_USERNAME      - Lagoon admin username (default: lagoonadmin)
+#   LAGOON_PASSWORD      - Lagoon admin password (fetched from secret if not set)
+#   CLIENT_ID            - Keycloak client ID (default: lagoon-ui)
+#   LAGOON_INSECURE_TLS  - Set to 1 to disable TLS verification against
+#                          non-localhost endpoints (e.g. self-signed nip.io
+#                          dev clusters). Default: verify TLS.
 
 set -e
 
@@ -46,8 +49,11 @@ if [ -n "$CLIENT_SECRET" ]; then
     TOKEN_DATA="${TOKEN_DATA}&client_secret=${CLIENT_SECRET}"
 fi
 
-# Get token
-TOKEN_RESPONSE=$(curl -s -k -X POST "${KEYCLOAK_URL}/auth/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" \
+# Get token. Verify TLS by default for non-localhost endpoints; opt out via
+# LAGOON_INSECURE_TLS=1 (e.g. self-signed dev clusters).
+TOKEN_URL="${KEYCLOAK_URL}/auth/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token"
+# shellcheck disable=SC2046  # word splitting is intentional: helper emits flag(s) or nothing
+TOKEN_RESPONSE=$(curl -s $(curl_insecure_for_url "$TOKEN_URL") -X POST "$TOKEN_URL" \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "$TOKEN_DATA" 2>&1)
 

--- a/scripts/list-deploy-targets.sh
+++ b/scripts/list-deploy-targets.sh
@@ -33,8 +33,11 @@ if [ -z "$LAGOON_TOKEN" ]; then
     exit 1
 fi
 
-# Query deploy targets
-RESPONSE=$(curl -s -k -H "Authorization: Bearer $LAGOON_TOKEN" \
+# Query deploy targets. Verify TLS by default for non-localhost endpoints;
+# opt out via LAGOON_INSECURE_TLS=1 (e.g. self-signed dev clusters).
+# shellcheck disable=SC2046  # word splitting is intentional: helper emits flag(s) or nothing
+RESPONSE=$(curl -s $(curl_insecure_for_url "$LAGOON_API_URL") \
+    -H "Authorization: Bearer $LAGOON_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"query": "{ allKubernetes { id name cloudProvider cloudRegion consoleUrl disabled } }"}' \
     "$LAGOON_API_URL")


### PR DESCRIPTION
## Summary

Replace unconditional `curl -k` in `get-token.sh` and `list-deploy-targets.sh` with a helper that disables TLS verification only for localhost targets, or when the caller explicitly opts in via `LAGOON_INSECURE_TLS=1`.

Fixes #224.

## What changed

`scripts/common.sh` adds `curl_insecure_for_url()`:

\`\`\`bash
curl_insecure_for_url() {
    local url="\$1"
    local host
    host=\$(echo "\$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' | sed -E 's#[/:?#].*\$##')
    case "\$host" in
        localhost|127.0.0.1|::1)
            echo "-k"
            ;;
        *)
            if [ "\${LAGOON_INSECURE_TLS:-}" = "1" ]; then
                log_warn "LAGOON_INSECURE_TLS=1: disabling TLS verification for \$host" >&2
                echo "-k"
            fi
            ;;
    esac
}
\`\`\`

`scripts/get-token.sh:50` and `scripts/list-deploy-targets.sh:37` switch from `curl -s -k` to `curl -s \$(curl_insecure_for_url "\$URL")`.

## Behavior matrix (verified)

| Target | Before | After |
|---|---|---|
| `http://localhost:8080` | `-k` | `-k` (no change; -k is moot on loopback but harmless) |
| `http://127.0.0.1:7080` | `-k` | `-k` |
| `https://keycloak.prod-west.cluster.tag1.io` | `-k` (silent MITM) | TLS verified (the fix) |
| `https://keycloak.<ip>.nip.io` (dev self-signed) | `-k` | TLS verified by default; `LAGOON_INSECURE_TLS=1` opts back in with a stderr warning |

## Out of scope (left for a follow-up)

The admin password in `get-token.sh` is still passed via `curl -d`, visible in the process list on shared hosts. Switching to `--data @-` via stdin would close that hole; left out to keep this PR focused. Mentioned in the issue's "Recommended fix" but not blocking.

## Rejected alternative

Replacing `-k` outright instead of gating it. Rejected because the localhost loopback case is intentional dev convenience (port-forwards from kind clusters), and removing `-k` there would force users to set up trust for a self-signed cert just to talk to `http://localhost:8080`. The gate keeps the UX while closing the silent-MITM path on remote endpoints.

## Test plan

- [ ] Sourcing `common.sh` does not error on any preset
- [ ] `./scripts/get-token.sh` against a local kind cluster still works (no behavior change for localhost)
- [ ] `./scripts/get-token.sh` against a real https Keycloak (e.g. nip.io) fails with TLS error by default; succeeds with `LAGOON_INSECURE_TLS=1` and prints the warning
- [ ] `./scripts/list-deploy-targets.sh` against a local cluster still works