### PR TITLE
fix(release): sync nodejs lockfile and broaden version-consistency check (#205, #206)

### DIFF
--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Check that version strings match across all provider files
+# Check that version strings match across all provider and SDK files.
+#
+# This script is the safety net for releases. Every published artifact
+# that carries a version string should be listed here so a stale value
+# fails CI rather than shipping silently.
 
 set -euo pipefail
 
@@ -8,33 +12,50 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$REPO_ROOT"
 
-# Extract versions from each file
+# Authoritative source: provider main.go.
 VERSION_MAIN=$(grep -E '^var Version = ' provider/cmd/pulumi-resource-lagoon/main.go | sed 's/.*"\(.*\)".*/\1/')
-VERSION_MAKEFILE=$(grep -E '^PROVIDER_VERSION \?= ' Makefile | awk '{print $3}')
-VERSION_SCHEMA=$(grep -E '^\s*"version":' provider/schema.json | head -1 | sed 's/.*"\(.*\)".*/\1/')
-VERSION_PYTHON=$(grep -E '^\s*version = ' sdk/python/pyproject.toml | sed 's/.*"\(.*\)".*/\1/')
-VERSION_NODEJS=$(grep -E '^\s*"version":' sdk/nodejs/package.json | head -1 | sed 's/.*"\(.*\)".*/\1/')
 
-echo "Version check:"
-echo "  main.go:         $VERSION_MAIN"
-echo "  Makefile:        $VERSION_MAKEFILE"
-echo "  schema.json:     $VERSION_SCHEMA"
-echo "  pyproject.toml:  $VERSION_PYTHON"
-echo "  package.json:    $VERSION_NODEJS"
+# Each entry below is "Label|extracted value". Extraction is per-file because
+# formats differ (TOML, JSON top-level, JSON nested, XML, plaintext).
+declare -a checks=()
+
+add_check() {
+    checks+=("$1|$2")
+}
+
+add_check "Makefile"                    "$(grep -E '^PROVIDER_VERSION \?= ' Makefile | awk '{print $3}')"
+add_check "schema.json"                 "$(jq -r '.version' provider/schema.json)"
+add_check "pyproject.toml"              "$(grep -E '^\s*version = ' sdk/python/pyproject.toml | sed 's/.*"\(.*\)".*/\1/')"
+add_check "package.json"                "$(jq -r '.version' sdk/nodejs/package.json)"
+add_check "package-lock.json (root)"    "$(jq -r '.version' sdk/nodejs/package-lock.json)"
+add_check "package-lock.json (pkg)"     "$(jq -r '.packages."".version' sdk/nodejs/package-lock.json)"
+add_check "go pulumi-plugin.json"       "$(jq -r '.version' sdk/go/lagoon/pulumi-plugin.json)"
+add_check "python pulumi-plugin.json"   "$(jq -r '.version' sdk/python/pulumi_lagoon/pulumi-plugin.json)"
+add_check "dotnet pulumi-plugin.json"   "$(jq -r '.version' sdk/dotnet/pulumi-plugin.json)"
+add_check "dotnet version.txt"          "$(tr -d '[:space:]' < sdk/dotnet/version.txt)"
+add_check "dotnet csproj <Version>"     "$(grep -oE '<Version>[^<]+</Version>' sdk/dotnet/Tag1Consulting.Lagoon.csproj | sed -E 's#</?Version>##g')"
+
+echo "Version check (expected: $VERSION_MAIN)"
+echo "  main.go: $VERSION_MAIN"
+
+mismatched=()
+for entry in "${checks[@]}"; do
+    label="${entry%%|*}"
+    value="${entry#*|}"
+    printf '  %-30s %s\n' "$label:" "$value"
+    if [ "$value" != "$VERSION_MAIN" ]; then
+        mismatched+=("$label ($value)")
+    fi
+done
 echo
 
-# Check all match
-if [ "$VERSION_MAIN" = "$VERSION_MAKEFILE" ] && \
-   [ "$VERSION_MAIN" = "$VERSION_SCHEMA" ] && \
-   [ "$VERSION_MAIN" = "$VERSION_PYTHON" ] && \
-   [ "$VERSION_MAIN" = "$VERSION_NODEJS" ]; then
-  echo "✓ All versions match: $VERSION_MAIN"
-  exit 0
-else
-  echo "✗ Version mismatch detected:"
-  [ "$VERSION_MAIN" != "$VERSION_MAKEFILE" ] && echo "  main.go ($VERSION_MAIN) != Makefile ($VERSION_MAKEFILE)"
-  [ "$VERSION_MAIN" != "$VERSION_SCHEMA" ] && echo "  main.go ($VERSION_MAIN) != schema.json ($VERSION_SCHEMA)"
-  [ "$VERSION_MAIN" != "$VERSION_PYTHON" ] && echo "  main.go ($VERSION_MAIN) != pyproject.toml ($VERSION_PYTHON)"
-  [ "$VERSION_MAIN" != "$VERSION_NODEJS" ] && echo "  main.go ($VERSION_MAIN) != package.json ($VERSION_NODEJS)"
-  exit 1
+if [ ${#mismatched[@]} -eq 0 ]; then
+    echo "✓ All versions match: $VERSION_MAIN"
+    exit 0
 fi
+
+echo "✗ Version mismatch detected:"
+for m in "${mismatched[@]}"; do
+    echo "  main.go ($VERSION_MAIN) != $m"
+done
+exit 1

--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@tag1consulting/pulumi-lagoon",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@tag1consulting/pulumi-lagoon",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@pulumi/pulumi": "^3.142.0"


### PR DESCRIPTION
## Summary

- Regenerate `sdk/nodejs/package-lock.json` to match `package.json` 0.5.1 (was stuck at 0.5.0; v0.5.1 shipped with the drift).
- Expand `scripts/check-version-consistency.sh` to cover six additional version-bearing artifacts so future drift fails CI rather than slipping through release prep.

Closes #205
Closes #206

## What changed

`scripts/check-version-consistency.sh` now validates 11 inputs against the authoritative version in `provider/cmd/pulumi-resource-lagoon/main.go`:

| Source | Was checked? |
|---|---|
| `Makefile` PROVIDER_VERSION | yes |
| `provider/schema.json` | yes |
| `sdk/python/pyproject.toml` | yes |
| `sdk/nodejs/package.json` | yes |
| `sdk/nodejs/package-lock.json` (root + `""` package) | **new** |
| `sdk/go/lagoon/pulumi-plugin.json` | **new** |
| `sdk/python/pulumi_lagoon/pulumi-plugin.json` | **new** |
| `sdk/dotnet/pulumi-plugin.json` | **new** |
| `sdk/dotnet/version.txt` | **new** |
| `sdk/dotnet/Tag1Consulting.Lagoon.csproj` `<Version>` | **new** |

JSON values now extract via `jq` rather than regex over `grep`/`sed`, so the parser handles ordering and quoting variation predictably.

## Verified

- Fresh tree → all 11 inputs read `0.5.1`, exit 0.
- Forced `9.9.9` into `sdk/go/lagoon/pulumi-plugin.json` → script flags the mismatch and exits 1.

## Out of scope

CI integration is unchanged; this PR only fixes the script and the lockfile. If `check-version-consistency.sh` is not currently invoked by `release-prep`, that's worth a follow-up — but it would have surfaced #205 even on local invocation, so the fix stands on its own.

## Rejected alternative

Adding a release-time `npm install --package-lock-only` step in `.github/workflows/publish.yml` instead of expanding the consistency check. Rejected because the lockfile drift is one symptom of the broader gap (six other files were unchecked); the check is the right place to catch the whole class.

## Test plan

- [ ] CI passes
- [ ] `bash scripts/check-version-consistency.sh` exits 0 locally on this branch
- [ ] (manual sanity) Force a version mismatch in any tracked file and confirm the script exits 1