### PR TITLE
fix(client): truncate upstream HTTP response bodies in error messages (#221)

### DIFF
--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -197,12 +197,12 @@ func (c *Client) executeOnce(ctx context.Context, query string, variables map[st
 
 	if resp.StatusCode >= 500 {
 		return nil, &LagoonConnectionError{
-			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)),
+			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncateErrorBody(respBody)),
 		}
 	}
 	if resp.StatusCode >= 400 {
 		return nil, &LagoonAPIError{
-			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)),
+			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, truncateErrorBody(respBody)),
 		}
 	}
 
@@ -316,6 +316,23 @@ func (c *Client) DetectAPIVersion(ctx context.Context) string {
 // IsNewAPI returns true if the API is v2.30.0+.
 func (c *Client) IsNewAPI(ctx context.Context) bool {
 	return c.DetectAPIVersion(ctx) == "new"
+}
+
+// maxErrorBodyBytes caps how much of an upstream HTTP response body is
+// embedded into a returned error message. Upstream bodies can be large or
+// occasionally surface unexpected content; bounding the size keeps logs
+// readable and limits how much arbitrary server output reaches operators.
+const maxErrorBodyBytes = 1024
+
+// truncateErrorBody returns the body unchanged if it fits within
+// maxErrorBodyBytes, otherwise the first maxErrorBodyBytes bytes followed
+// by a "...(truncated, N more bytes)" marker that records how much was
+// dropped so the truncation is visible in error output.
+func truncateErrorBody(body []byte) string {
+	if len(body) <= maxErrorBodyBytes {
+		return string(body)
+	}
+	return fmt.Sprintf("%s...(truncated, %d more bytes)", body[:maxErrorBodyBytes], len(body)-maxErrorBodyBytes)
 }
 
 // extractField extracts a top-level field from a raw JSON data response.

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -102,6 +102,76 @@ func TestExecute_HTTPError(t *testing.T) {
 	}
 }
 
+func TestTruncateErrorBody(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		contains string
+		exact    string
+	}{
+		{
+			name:  "empty body",
+			input: []byte(""),
+			exact: "",
+		},
+		{
+			name:  "short body unchanged",
+			input: []byte(`{"error":"not found"}`),
+			exact: `{"error":"not found"}`,
+		},
+		{
+			name:  "exactly at limit unchanged",
+			input: []byte(strings.Repeat("a", maxErrorBodyBytes)),
+			exact: strings.Repeat("a", maxErrorBodyBytes),
+		},
+		{
+			name:     "over limit truncated with marker",
+			input:    []byte(strings.Repeat("b", maxErrorBodyBytes+500)),
+			contains: fmt.Sprintf("...(truncated, %d more bytes)", 500),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateErrorBody(tt.input)
+			if tt.exact != "" || (tt.exact == "" && tt.contains == "") {
+				if got != tt.exact {
+					t.Errorf("expected exact %q, got %q", tt.exact, got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("expected output to contain %q, got %q", tt.contains, got)
+			}
+			// Truncated output must start with the original prefix.
+			if !strings.HasPrefix(got, string(tt.input[:maxErrorBodyBytes])) {
+				t.Error("truncated output should start with first maxErrorBodyBytes of input")
+			}
+		})
+	}
+}
+
+func TestExecute_HTTPError_LargeBodyTruncated(t *testing.T) {
+	hugeBody := strings.Repeat("X", maxErrorBodyBytes*4)
+	server := mockGraphQLServerRaw(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(hugeBody))
+	})
+	defer server.Close()
+
+	c := NewClient(server.URL, "test-token", WithMaxRetries(0))
+	_, err := c.Execute(context.Background(), "query { test }", nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if len(msg) > maxErrorBodyBytes+512 {
+		t.Errorf("error message too large: %d bytes (cap ~%d)", len(msg), maxErrorBodyBytes+512)
+	}
+	if !strings.Contains(msg, "truncated") {
+		t.Errorf("expected truncation marker in error message, got: %s", msg)
+	}
+}
+
 func TestExecute_RetryOnConnectionError(t *testing.T) {
 	var attempts int32
 	server := mockGraphQLServerRaw(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Cap the upstream HTTP response body embedded into `LagoonAPIError` / `LagoonConnectionError` messages at 1024 bytes. When the cap fires, the error gains a `...(truncated, N more bytes)` marker so the truncation is visible.

Defensive only — no active leak observed. Token is sent as a header and never echoed into these errors. The concern is bounding how much arbitrary upstream content can reach operator logs if the server's behavior changes or the body happens to be large.

Closes #221

## What changed

`provider/pkg/client/client.go`:
- Add `maxErrorBodyBytes = 1024` and a `truncateErrorBody([]byte) string` helper.
- Wrap both `respBody` interpolations in `executeOnce` (4xx and 5xx branches) with the helper.

## Test plan

- [x] `go test ./pkg/client/` passes
- [x] `TestTruncateErrorBody` covers boundary cases (empty, short, exactly at limit, over limit)
- [x] `TestExecute_HTTPError_LargeBodyTruncated` issues a 4xx with a 4096-byte body and asserts the resulting error stays bounded and contains the truncation marker
- [ ] CI passes

## Rejected alternative

Stripping the body entirely on 4xx/5xx and substituting a static "upstream rejected request" message. Rejected because the body is genuinely useful for diagnosis (Lagoon GraphQL errors carry the failing field path, project name, etc.); truncation preserves that signal while bounding the worst case.

## Out of scope

Sanitizing the body for known sensitive patterns (token-shaped strings, etc.). That's a separate hardening pass and would need a curated allowlist of known-safe Lagoon error shapes; not warranted given there's no observed echo of credentials today.