### PR TITLE
fix(example): remove hardcoded Harbor admin password fallback (#220)

### DIFF
--- a/examples/multi-cluster/__main__.py
+++ b/examples/multi-cluster/__main__.py
@@ -236,13 +236,22 @@ if install_lagoon_components:
 # =============================================================================
 
 lagoon_core = None
-if prod_provider is not None and install_lagoon_components and lagoon_secrets is not None:
+if (
+    prod_provider is not None
+    and install_lagoon_components
+    and lagoon_secrets is not None
+    and prod_harbor is not None
+):
     pulumi.log.info("Installing Lagoon core on production cluster...")
 
     # Build dependency list - include Harbor and CoreDNS if available
-    lagoon_core_deps = [prod_ingress.service, prod_cert, lagoon_core_ns, prod_coredns]
-    if prod_harbor is not None:
-        lagoon_core_deps.append(prod_harbor.release)
+    lagoon_core_deps = [
+        prod_ingress.service,
+        prod_cert,
+        lagoon_core_ns,
+        prod_coredns,
+        prod_harbor.release,
+    ]
 
     lagoon_core = install_lagoon_core(
         "prod-lagoon-core",

--- a/examples/multi-cluster/lagoon/core.py
+++ b/examples/multi-cluster/lagoon/core.py
@@ -71,13 +71,21 @@ def install_lagoon_core(
     keycloak_url = domain_config.lagoon_keycloak_url
     webhook_url = f"https://{domain_config.lagoon_webhook}{domain_config._port_suffix}"
 
-    # Harbor URL and registry - required by lagoon-core chart
-    # Use the provided Harbor or a default
-    harbor_url = harbor.url if harbor else f"https://{domain_config.harbor}"
-    # Registry is the Harbor hostname without protocol
+    # Harbor URL and registry - required by lagoon-core chart for image pushes.
+    # We require a real Harbor object rather than substituting a placeholder
+    # password: a literal fallback would silently configure Lagoon to
+    # authenticate against a registry that does not exist with a known-in-
+    # the-clear credential, which is misleading rather than helpful when the
+    # caller forgot to install Harbor.
+    if harbor is None:
+        raise ValueError(
+            "install_lagoon_core requires a Harbor instance (got harbor=None). "
+            "Install Harbor first via install_harbor() or set "
+            "install_harbor_registry=True in the example config."
+        )
+    harbor_url = harbor.url
     registry = harbor_url.replace("https://", "").replace("http://", "")
-    # Harbor admin password - required for Lagoon to push images
-    harbor_admin_password = harbor.admin_password if harbor else "Harbor2024!"
+    harbor_admin_password = harbor.admin_password
 
     # Internal Keycloak URL for API communication (must include /auth path)
     keycloak_internal_url = (


### PR DESCRIPTION
## Summary

`install_lagoon_core()` in the multi-cluster example silently fell back to the literal `"Harbor2024!"` admin password when called without a Harbor object. That configured Lagoon to authenticate against a registry that does not exist with a known-in-the-clear credential — misleading rather than helpful for any reader copying the example.

Replace the literal with a `ValueError` that names the missing prerequisite. Tighten the call-site gate in `__main__.py` so the example only attempts to install Lagoon core when `prod_harbor` is present, so the new error path doesn't fire when `install_harbor_registry` is intentionally false.

Closes #220

## What changed

`examples/multi-cluster/lagoon/core.py:80`:
- Remove `harbor_admin_password = harbor.admin_password if harbor else "Harbor2024!"`.
- Raise `ValueError` with a directive message ("install Harbor first or set `install_harbor_registry=True`") when `harbor is None`.
- Drop the parallel URL fallback that referenced `domain_config.harbor` — it would have pointed at a non-existent host anyway.

`examples/multi-cluster/__main__.py:239`:
- Add `prod_harbor is not None` to the Lagoon-core install gate.
- Inline the now-unconditional `prod_harbor.release` dependency.

## Behavior matrix

| `install_harbor_registry` | Before | After |
|---|---|---|
| true (default) | Harbor installed → real password used | unchanged |
| false | Lagoon installed pointing at non-existent Harbor with `Harbor2024!` | Lagoon install skipped (with the existing dev-only example caveat) |

## Provider impact

None — this is example-only Python; no schema or SDK changes.

## Rejected alternative

Generating a `random.RandomPassword` as the fallback. Rejected because the value is supposed to match a real Harbor instance's admin password, not be invented at install time. A random password would still result in failed auth against a non-existent registry; failing loudly at the Pulumi program is more helpful than failing later inside the chart.

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` confirms both files parse
- [ ] CI passes
- [ ] (manual) Running the multi-cluster example with `install_harbor_registry=true` (default) deploys end-to-end as before
- [ ] (manual) Running with `install_harbor_registry=false` skips Lagoon core install rather than provisioning a broken stack