### PR TITLE
test(config): error-check env mutations and document GetLogger contract (#174, #175)

### DIFF
--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -55,6 +55,11 @@ func (c *LagoonConfig) Annotate(a infer.Annotator) {
 // Configure validates the config and prepares it for use.
 // Called by the Pulumi engine when the provider is configured.
 func (c *LagoonConfig) Configure(ctx context.Context) error {
+	// p.GetLogger returns a Logger value (not a pointer), and when the
+	// context carries no logger key it falls back to a slog-backed sink
+	// rather than returning a nil sink. Tests can therefore call
+	// Configure with context.TODO() without a nil-deref on Debugf. See
+	// pulumi-go-provider/logging.go.
 	log := p.GetLogger(ctx)
 
 	c.Token = strings.TrimSpace(c.Token)

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -12,6 +12,33 @@ import (
 	"github.com/pulumi/pulumi-go-provider/infer"
 )
 
+// requireUnsetEnv removes the named environment variables for the duration
+// of the test and restores their original values on test cleanup. Errors
+// from os.Unsetenv and os.Setenv are surfaced via t.Fatalf / t.Errorf
+// rather than silently dropped, so a failure to mutate the environment
+// does not corrupt subsequent tests.
+//
+// Use this in place of bare os.Unsetenv + defer save/restore for tests
+// that need a variable absent. For tests that only need a variable set
+// to a specific value, prefer t.Setenv directly (it already auto-restores
+// on cleanup).
+func requireUnsetEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			key, val := k, v
+			t.Cleanup(func() {
+				if err := os.Setenv(key, val); err != nil {
+					t.Errorf("restore %s: %v", key, err)
+				}
+			})
+		}
+		if err := os.Unsetenv(k); err != nil {
+			t.Fatalf("unset %s: %v", k, err)
+		}
+	}
+}
+
 func TestGenerateAdminTokenFromSecret(t *testing.T) {
 	secret := "test-secret-key-for-jwt"
 	audience := "api.test"
@@ -148,23 +175,7 @@ func TestConfigure_WithJWTSecret(t *testing.T) {
 }
 
 func TestConfigure_NoAuth(t *testing.T) {
-	// Clear env vars that might interfere
-	origToken, hadToken := os.LookupEnv("LAGOON_TOKEN")
-	origSecret, hadSecret := os.LookupEnv("LAGOON_JWT_SECRET")
-	os.Unsetenv("LAGOON_TOKEN")
-	os.Unsetenv("LAGOON_JWT_SECRET")
-	defer func() {
-		if hadToken {
-			os.Setenv("LAGOON_TOKEN", origToken)
-		} else {
-			os.Unsetenv("LAGOON_TOKEN")
-		}
-		if hadSecret {
-			os.Setenv("LAGOON_JWT_SECRET", origSecret)
-		} else {
-			os.Unsetenv("LAGOON_JWT_SECRET")
-		}
-	}()
+	requireUnsetEnv(t, "LAGOON_TOKEN", "LAGOON_JWT_SECRET")
 
 	cfg := &LagoonConfig{
 		APIUrl: "https://api.test/graphql",
@@ -181,20 +192,8 @@ func TestConfigure_NoAuth(t *testing.T) {
 }
 
 func TestConfigure_EnvVarToken(t *testing.T) {
-	origToken := os.Getenv("LAGOON_TOKEN")
-	origSecret := os.Getenv("LAGOON_JWT_SECRET")
-	os.Setenv("LAGOON_TOKEN", "env-token")
-	os.Unsetenv("LAGOON_JWT_SECRET")
-	defer func() {
-		if origToken != "" {
-			os.Setenv("LAGOON_TOKEN", origToken)
-		} else {
-			os.Unsetenv("LAGOON_TOKEN")
-		}
-		if origSecret != "" {
-			os.Setenv("LAGOON_JWT_SECRET", origSecret)
-		}
-	}()
+	requireUnsetEnv(t, "LAGOON_JWT_SECRET")
+	t.Setenv("LAGOON_TOKEN", "env-token")
 
 	cfg := &LagoonConfig{
 		APIUrl: "https://api.test/graphql",
@@ -210,22 +209,8 @@ func TestConfigure_EnvVarToken(t *testing.T) {
 }
 
 func TestConfigure_EnvVarJWTSecret(t *testing.T) {
-	origToken := os.Getenv("LAGOON_TOKEN")
-	origSecret := os.Getenv("LAGOON_JWT_SECRET")
-	os.Unsetenv("LAGOON_TOKEN")
-	os.Setenv("LAGOON_JWT_SECRET", "env-jwt-secret")
-	defer func() {
-		if origToken != "" {
-			os.Setenv("LAGOON_TOKEN", origToken)
-		} else {
-			os.Unsetenv("LAGOON_TOKEN")
-		}
-		if origSecret != "" {
-			os.Setenv("LAGOON_JWT_SECRET", origSecret)
-		} else {
-			os.Unsetenv("LAGOON_JWT_SECRET")
-		}
-	}()
+	requireUnsetEnv(t, "LAGOON_TOKEN")
+	t.Setenv("LAGOON_JWT_SECRET", "env-jwt-secret")
 
 	cfg := &LagoonConfig{
 		APIUrl:      "https://api.test/graphql",
@@ -303,18 +288,7 @@ func TestConfigure_TokenPrecedence(t *testing.T) {
 }
 
 func TestConfigure_TrimsJWTSecretWhitespace(t *testing.T) {
-	origToken := os.Getenv("LAGOON_TOKEN")
-	origSecret := os.Getenv("LAGOON_JWT_SECRET")
-	os.Unsetenv("LAGOON_TOKEN")
-	os.Unsetenv("LAGOON_JWT_SECRET")
-	defer func() {
-		if origToken != "" {
-			os.Setenv("LAGOON_TOKEN", origToken)
-		}
-		if origSecret != "" {
-			os.Setenv("LAGOON_JWT_SECRET", origSecret)
-		}
-	}()
+	requireUnsetEnv(t, "LAGOON_TOKEN", "LAGOON_JWT_SECRET")
 
 	secret := "test-secret-for-trimming"
 
@@ -391,20 +365,8 @@ func TestConfigure_TrimsTokenWhitespace(t *testing.T) {
 }
 
 func TestConfigure_TrimsEnvVarWhitespace(t *testing.T) {
-	origToken := os.Getenv("LAGOON_TOKEN")
-	origSecret := os.Getenv("LAGOON_JWT_SECRET")
-	os.Setenv("LAGOON_TOKEN", "  env-token\n")
-	os.Unsetenv("LAGOON_JWT_SECRET")
-	defer func() {
-		if origToken != "" {
-			os.Setenv("LAGOON_TOKEN", origToken)
-		} else {
-			os.Unsetenv("LAGOON_TOKEN")
-		}
-		if origSecret != "" {
-			os.Setenv("LAGOON_JWT_SECRET", origSecret)
-		}
-	}()
+	requireUnsetEnv(t, "LAGOON_JWT_SECRET")
+	t.Setenv("LAGOON_TOKEN", "  env-token\n")
 
 	cfg := &LagoonConfig{
 		APIUrl: "https://api.test/graphql",
@@ -418,18 +380,7 @@ func TestConfigure_TrimsEnvVarWhitespace(t *testing.T) {
 }
 
 func TestConfigure_JWTSecretGeneratesToken(t *testing.T) {
-	origToken := os.Getenv("LAGOON_TOKEN")
-	origSecret := os.Getenv("LAGOON_JWT_SECRET")
-	os.Unsetenv("LAGOON_TOKEN")
-	os.Unsetenv("LAGOON_JWT_SECRET")
-	defer func() {
-		if origToken != "" {
-			os.Setenv("LAGOON_TOKEN", origToken)
-		}
-		if origSecret != "" {
-			os.Setenv("LAGOON_JWT_SECRET", origSecret)
-		}
-	}()
+	requireUnsetEnv(t, "LAGOON_TOKEN", "LAGOON_JWT_SECRET")
 
 	cfg := &LagoonConfig{
 		APIUrl:      "https://api.test/graphql",


### PR DESCRIPTION
## Summary

Two low-severity hygiene items flagged by silent-failure-hunter on PR #173.

- **#175** — Replace bare `os.Unsetenv` calls (return values silently dropped) and per-test save/restore boilerplate in `config_test.go` with a single `requireUnsetEnv` helper that uses `t.Cleanup` and surfaces `os.Setenv` / `os.Unsetenv` errors. Combined with `t.Setenv` for the set side, net -44 lines across the test file.
- **#174** — `p.GetLogger(ctx)` was called in `Configure` with no nil guard. Verified in pulumi-go-provider v1.3.0 (`logging.go:77-89`) that `GetLogger` returns a `Logger` value (not a pointer) and falls back to a slog-backed sink when the context has no logger key, so `context.TODO()` in tests is safe. Add a comment recording that contract so a future framework change forces re-verification.

Closes #174
Closes #175

## What changed

`provider/pkg/config/config.go`:
- Add a 5-line comment on the `p.GetLogger(ctx)` call site documenting the non-nil guarantee and pointing at the upstream source.

`provider/pkg/config/config_test.go`:
- Add `requireUnsetEnv(t, keys...)` helper that handles save/restore via `t.Cleanup` and fails the test on `os.Setenv` / `os.Unsetenv` errors.
- Convert six tests (`TestConfigure_NoAuth`, `TestConfigure_EnvVarToken`, `TestConfigure_EnvVarJWTSecret`, `TestConfigure_TrimsJWTSecretWhitespace`, `TestConfigure_TrimsEnvVarWhitespace`, `TestConfigure_JWTSecretGeneratesToken`) to the new helper plus `t.Setenv` for the set side.

## Test plan

- [x] `go test ./pkg/config/ -v` — all tests pass
- [ ] CI passes

## Rejected alternative

Adding nil guards or a no-op fallback for `p.GetLogger`. Rejected after reading the upstream source: the function constructs its return value on every call path and never returns nil, so guards would be dead code. Documenting the contract is the actionable item from #174's investigation list.