### PR TITLE
fix(route): refresh Updated timestamp after successful update

### DIFF
--- a/provider/pkg/resources/route.go
+++ b/provider/pkg/resources/route.go
@@ -276,12 +276,34 @@ func (r *Route) Update(ctx context.Context, req infer.UpdateRequest[RouteArgs, R
 		}
 	}
 
+	// Refresh the updated timestamp from the server. Lagoon stamps `updated`
+	// on every mutation that touches the route (scalar patch, annotation
+	// reconcile, alternative-name reconcile, path-route reconcile, environment
+	// attachment), and we may have called several of those above. Rather
+	// than thread the timestamp out of every reconcile path, do a single
+	// targeted read here so the returned state always carries a fresh value
+	// instead of dropping the field. If the read fails we fall back to the
+	// state's prior timestamp rather than failing the whole update — the
+	// mutation already succeeded and the client will see the freshness on
+	// the next refresh.
+	updated := state.Updated
+	refreshed, err := c.GetRouteByDomain(ctx, args.ProjectName, args.Domain)
+	switch {
+	case err != nil:
+		p.GetLogger(ctx).Warningf(
+			"Route %s on project %s updated, but failed to refresh updated timestamp: %v",
+			args.Domain, args.ProjectName, err)
+	case refreshed != nil && refreshed.Updated != "":
+		updated = refreshed.Updated
+	}
+
 	return infer.UpdateResponse[RouteState]{
 		Output: RouteState{
 			RouteArgs: args,
 			LagoonID:  state.LagoonID,
 			Source:    state.Source,
 			Created:   state.Created,
+			Updated:   updated,
 		},
 	}, nil
 }

--- a/provider/pkg/resources/route_crud_test.go
+++ b/provider/pkg/resources/route_crud_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -332,6 +333,59 @@ func TestRouteUpdate_EnvironmentDetach(t *testing.T) {
 	}
 	if !detachCalled {
 		t.Error("expected RemoveRouteFromEnvironment to be called when clearing environment")
+	}
+}
+
+func TestRouteUpdate_RefreshesUpdatedTimestamp(t *testing.T) {
+	tlsAcme := false
+	mock := &mockLagoonClient{
+		updateRouteOnProjectFn: func(_ context.Context, _ int, _ map[string]any) (*client.Route, error) {
+			return &client.Route{ID: 1, Domain: "example.com"}, nil
+		},
+		getRouteByDomainFn: func(_ context.Context, projectName, domain string) (*client.Route, error) {
+			return &client.Route{ID: 1, Domain: domain, ProjectName: projectName, Updated: "2026-06-09T20:30:00Z"}, nil
+		},
+	}
+	ctx := testCtx(mock)
+	r := &Route{}
+	oldTLS := true
+	resp, err := r.Update(ctx, infer.UpdateRequest[RouteArgs, RouteState]{
+		Inputs: RouteArgs{ProjectName: "p", Domain: "example.com", TLSAcme: &tlsAcme},
+		State:  RouteState{RouteArgs: RouteArgs{ProjectName: "p", Domain: "example.com", TLSAcme: &oldTLS}, LagoonID: 1, Created: "2026-06-09T20:00:00Z", Updated: "2026-06-09T20:00:00Z"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Output.Updated != "2026-06-09T20:30:00Z" {
+		t.Errorf("expected Updated=2026-06-09T20:30:00Z (refreshed from API), got %q", resp.Output.Updated)
+	}
+	if resp.Output.Created != "2026-06-09T20:00:00Z" {
+		t.Errorf("Created should be preserved, got %q", resp.Output.Created)
+	}
+}
+
+func TestRouteUpdate_FallsBackToStateUpdatedOnReadFailure(t *testing.T) {
+	tlsAcme := false
+	mock := &mockLagoonClient{
+		updateRouteOnProjectFn: func(_ context.Context, _ int, _ map[string]any) (*client.Route, error) {
+			return &client.Route{ID: 1, Domain: "example.com"}, nil
+		},
+		getRouteByDomainFn: func(_ context.Context, _, _ string) (*client.Route, error) {
+			return nil, errors.New("transient API error")
+		},
+	}
+	ctx := testCtx(mock)
+	r := &Route{}
+	oldTLS := true
+	resp, err := r.Update(ctx, infer.UpdateRequest[RouteArgs, RouteState]{
+		Inputs: RouteArgs{ProjectName: "p", Domain: "example.com", TLSAcme: &tlsAcme},
+		State:  RouteState{RouteArgs: RouteArgs{ProjectName: "p", Domain: "example.com", TLSAcme: &oldTLS}, LagoonID: 1, Updated: "2026-06-09T20:00:00Z"},
+	})
+	if err != nil {
+		t.Fatalf("Update should not fail when refresh fails (mutation already succeeded): %v", err)
+	}
+	if resp.Output.Updated != "2026-06-09T20:00:00Z" {
+		t.Errorf("expected fallback to state.Updated=2026-06-09T20:00:00Z, got %q", resp.Output.Updated)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Route.Update` was returning the pre-update `Updated` timestamp because Lagoon's `updateRoute` mutation does not return a timestamp in its response
- Adds a post-update `GetRouteByDomain` call to refresh the `Updated` field from the server after a successful mutation
- On refresh failure, emits a provider warning and preserves `state.Updated` so the mutation result is not orphaned
- Also adds the missing `errors` import in `route_crud_test.go`

Closes #200

## Test plan

- [x] `TestRouteUpdate_RefreshesUpdatedTimestamp`: verifies the refreshed timestamp from the server is used in the returned state
- [x] `TestRouteUpdate_FallsBackToStateUpdatedOnReadFailure`: verifies Update succeeds and falls back to `state.Updated` when the post-update read fails
- [x] All existing `TestRouteUpdate_*` tests continue to pass
- [x] Full test suite: `make go-test`