### PR TITLE
fix(route): apply service, routeType, and primary on Update

### DIFF
--- a/provider/pkg/resources/route.go
+++ b/provider/pkg/resources/route.go
@@ -212,11 +212,25 @@ func (r *Route) Update(ctx context.Context, req infer.UpdateRequest[RouteArgs, R
 
 	// Build scalar patch
 	patch := map[string]any{}
+	if ptrDiffers(args.Service, state.Service) {
+		setOptional(patch, "service", args.Service)
+	}
 	if ptrBoolDiffers(args.TLSAcme, state.TLSAcme) {
 		setOptionalBool(patch, "tlsAcme", args.TLSAcme)
 	}
 	if ptrDiffers(args.Insecure, state.Insecure) {
 		setOptional(patch, "insecure", args.Insecure)
+	}
+	if ptrDiffers(args.RouteType, state.RouteType) {
+		if args.RouteType != nil {
+			upper := strings.ToUpper(*args.RouteType)
+			patch["type"] = upper
+		} else {
+			patch["type"] = nil
+		}
+	}
+	if ptrBoolDiffers(args.Primary, state.Primary) {
+		setOptionalBool(patch, "primary", args.Primary)
 	}
 	if ptrDiffers(args.MonitoringPath, state.MonitoringPath) {
 		setOptional(patch, "monitoringPath", args.MonitoringPath)

--- a/provider/pkg/resources/route_crud_test.go
+++ b/provider/pkg/resources/route_crud_test.go
@@ -235,6 +235,87 @@ func TestRouteUpdate_ScalarFields(t *testing.T) {
 	}
 }
 
+func TestRouteUpdate_ServiceFieldApplied(t *testing.T) {
+	var capturedPatch map[string]any
+	svc := "nginx"
+	mock := &mockLagoonClient{
+		updateRouteOnProjectFn: func(_ context.Context, _ int, input map[string]any) (*client.Route, error) {
+			capturedPatch, _ = input["patch"].(map[string]any)
+			return &client.Route{ID: 1, Domain: "example.com"}, nil
+		},
+	}
+	ctx := testCtx(mock)
+	r := &Route{}
+	oldSvc := "node"
+	_, err := r.Update(ctx, infer.UpdateRequest[RouteArgs, RouteState]{
+		Inputs: RouteArgs{ProjectName: "p", Domain: "example.com", Service: &svc},
+		State:  RouteState{RouteArgs: RouteArgs{ProjectName: "p", Domain: "example.com", Service: &oldSvc}, LagoonID: 1},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPatch == nil {
+		t.Fatal("expected UpdateRouteOnProject to be called with a patch")
+	}
+	if v, ok := capturedPatch["service"]; !ok || v != "nginx" {
+		t.Errorf("expected patch[service]=nginx, got %v", capturedPatch["service"])
+	}
+}
+
+func TestRouteUpdate_RouteTypeFieldApplied(t *testing.T) {
+	var capturedPatch map[string]any
+	rt := "active"
+	mock := &mockLagoonClient{
+		updateRouteOnProjectFn: func(_ context.Context, _ int, input map[string]any) (*client.Route, error) {
+			capturedPatch, _ = input["patch"].(map[string]any)
+			return &client.Route{ID: 1, Domain: "example.com"}, nil
+		},
+	}
+	ctx := testCtx(mock)
+	r := &Route{}
+	oldRT := "standard"
+	_, err := r.Update(ctx, infer.UpdateRequest[RouteArgs, RouteState]{
+		Inputs: RouteArgs{ProjectName: "p", Domain: "example.com", RouteType: &rt},
+		State:  RouteState{RouteArgs: RouteArgs{ProjectName: "p", Domain: "example.com", RouteType: &oldRT}, LagoonID: 1},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPatch == nil {
+		t.Fatal("expected UpdateRouteOnProject to be called with a patch")
+	}
+	if v, ok := capturedPatch["type"]; !ok || v != "ACTIVE" {
+		t.Errorf("expected patch[type]=ACTIVE (uppercased), got %v", capturedPatch["type"])
+	}
+}
+
+func TestRouteUpdate_PrimaryFieldApplied(t *testing.T) {
+	var capturedPatch map[string]any
+	primary := true
+	mock := &mockLagoonClient{
+		updateRouteOnProjectFn: func(_ context.Context, _ int, input map[string]any) (*client.Route, error) {
+			capturedPatch, _ = input["patch"].(map[string]any)
+			return &client.Route{ID: 1, Domain: "example.com"}, nil
+		},
+	}
+	ctx := testCtx(mock)
+	r := &Route{}
+	oldPrimary := false
+	_, err := r.Update(ctx, infer.UpdateRequest[RouteArgs, RouteState]{
+		Inputs: RouteArgs{ProjectName: "p", Domain: "example.com", Primary: &primary},
+		State:  RouteState{RouteArgs: RouteArgs{ProjectName: "p", Domain: "example.com", Primary: &oldPrimary}, LagoonID: 1},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedPatch == nil {
+		t.Fatal("expected UpdateRouteOnProject to be called with a patch")
+	}
+	if v, ok := capturedPatch["primary"]; !ok || v != true {
+		t.Errorf("expected patch[primary]=true, got %v", capturedPatch["primary"])
+	}
+}
+
 func TestRouteUpdate_AnnotationReconciliation(t *testing.T) {
 	removeCalled := false
 	addCalled := false


### PR DESCRIPTION
## Summary

- `Route.Update` was omitting `service`, `routeType`, and `primary` from the scalar patch sent to `UpdateRouteOnProject`
- Changes to those three fields were silently dropped unless `environment` changed simultaneously (only then were the values forwarded via `reconcileEnvironment`)
- Adds all three fields to the scalar patch block, using the same `ptrDiffers`/`ptrBoolDiffers` guard pattern already used for `tlsAcme` and `insecure`
- `routeType` is uppercased before insertion to match the GraphQL enum requirement (same behavior as Create)

Closes #198

## Test plan

- [ ] `TestRouteUpdate_ServiceFieldApplied`: verifies changing `service` sends the new value in the patch
- [ ] `TestRouteUpdate_RouteTypeFieldApplied`: verifies changing `routeType` sends the uppercased value (`"active"` → `"ACTIVE"`) in the patch
- [ ] `TestRouteUpdate_PrimaryFieldApplied`: verifies changing `primary` sends the new boolean value in the patch
- [ ] All existing `TestRouteUpdate_*` tests continue to pass
- [ ] Full test suite: `make go-test`