### PR TITLE
fix(project,deploytarget): remove silent adoption on duplicate create

### DIFF
--- a/provider/pkg/resources/deploytarget.go
+++ b/provider/pkg/resources/deploytarget.go
@@ -89,23 +89,10 @@ func (r *DeployTarget) Create(ctx context.Context, req infer.CreateRequest[Deplo
 
 	dt, err := c.CreateDeployTarget(ctx, input)
 	if err != nil {
-		if !client.IsDuplicateEntry(err) {
-			return infer.CreateResponse[DeployTargetState]{}, fmt.Errorf("failed to create deploy target: %w", err)
+		if client.IsDuplicateEntry(err) {
+			return infer.CreateResponse[DeployTargetState]{}, fmt.Errorf("deploy target %q already exists: use pulumi import to bring it under management", req.Inputs.Name)
 		}
-
-		// Resource already exists — adopt it by looking up by name and updating
-		existing, lookupErr := c.GetDeployTargetByName(ctx, req.Inputs.Name)
-		if lookupErr != nil {
-			return infer.CreateResponse[DeployTargetState]{}, fmt.Errorf("deploy target %q already exists but failed to look up: %w", req.Inputs.Name, lookupErr)
-		}
-
-		// Update the existing resource to match desired inputs
-		// Remove name — it's not updatable via the UpdateKubernetes mutation
-		delete(input, "name")
-		dt, err = c.UpdateDeployTarget(ctx, existing.ID, input)
-		if err != nil {
-			return infer.CreateResponse[DeployTargetState]{}, fmt.Errorf("deploy target %q already exists but failed to update: %w", req.Inputs.Name, err)
-		}
+		return infer.CreateResponse[DeployTargetState]{}, fmt.Errorf("failed to create deploy target: %w", err)
 	}
 
 	return infer.CreateResponse[DeployTargetState]{

--- a/provider/pkg/resources/deploytarget_crud_test.go
+++ b/provider/pkg/resources/deploytarget_crud_test.go
@@ -74,28 +74,25 @@ func TestDeployTargetCreate_DryRun(t *testing.T) {
 	}
 }
 
-func TestDeployTargetCreate_DuplicateAdopts(t *testing.T) {
+func TestDeployTargetCreate_DuplicateReturnsError(t *testing.T) {
 	mock := &mockLagoonClient{
 		createDeployTargetFn: func(_ context.Context, _ map[string]any) (*client.DeployTarget, error) {
 			return nil, &client.LagoonAPIError{Message: "Duplicate entry"}
 		},
-		getDeployTargetByNameFn: func(_ context.Context, name string) (*client.DeployTarget, error) {
-			return &client.DeployTarget{ID: 99, Name: name}, nil
-		},
-		updateDeployTargetFn: func(_ context.Context, id int, _ map[string]any) (*client.DeployTarget, error) {
-			return &client.DeployTarget{ID: id, Name: "mycluster", Created: "2024-01-01"}, nil
-		},
 	}
 	ctx := testCtx(mock)
 	r := &DeployTarget{}
-	resp, err := r.Create(ctx, infer.CreateRequest[DeployTargetArgs]{
+	_, err := r.Create(ctx, infer.CreateRequest[DeployTargetArgs]{
 		Inputs: DeployTargetArgs{Name: "mycluster", ConsoleURL: "https://k8s.example.com"},
 	})
-	if err != nil {
-		t.Fatalf("Create with duplicate should adopt: %v", err)
+	if err == nil {
+		t.Fatal("expected error when deploy target already exists")
 	}
-	if resp.ID != "99" {
-		t.Errorf("expected adopted ID '99', got %q", resp.ID)
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pulumi import") {
+		t.Errorf("expected 'pulumi import' hint in error, got: %v", err)
 	}
 }
 
@@ -334,31 +331,6 @@ func TestDeployTargetRead_InvalidID(t *testing.T) {
 	}
 }
 
-func TestDeployTargetCreate_DuplicateAdopt_UpdateFails(t *testing.T) {
-	mock := &mockLagoonClient{
-		createDeployTargetFn: func(_ context.Context, _ map[string]any) (*client.DeployTarget, error) {
-			return nil, &client.LagoonAPIError{Message: "Duplicate entry 'mycluster' for key 'name'"}
-		},
-		getDeployTargetByNameFn: func(_ context.Context, name string) (*client.DeployTarget, error) {
-			return &client.DeployTarget{ID: 99, Name: name}, nil
-		},
-		updateDeployTargetFn: func(_ context.Context, _ int, _ map[string]any) (*client.DeployTarget, error) {
-			return nil, fmt.Errorf("update failed")
-		},
-	}
-	ctx := testCtx(mock)
-	r := &DeployTarget{}
-	_, err := r.Create(ctx, infer.CreateRequest[DeployTargetArgs]{
-		Inputs: DeployTargetArgs{Name: "mycluster", ConsoleURL: "https://k8s.example.com"},
-	})
-	if err == nil {
-		t.Fatal("expected error when adopt-update fails")
-	}
-	if !strings.Contains(err.Error(), "failed to update") {
-		t.Errorf("expected error to mention update failure, got: %v", err)
-	}
-}
-
 func TestDeployTargetUpdate_APIError(t *testing.T) {
 	mock := &mockLagoonClient{
 		updateDeployTargetFn: func(_ context.Context, _ int, _ map[string]any) (*client.DeployTarget, error) {
@@ -407,21 +379,3 @@ func TestDeployTargetCreate_APIError(t *testing.T) {
 	}
 }
 
-func TestDeployTargetCreate_DuplicateAdopt_LookupFails(t *testing.T) {
-	mock := &mockLagoonClient{
-		createDeployTargetFn: func(_ context.Context, _ map[string]any) (*client.DeployTarget, error) {
-			return nil, &client.LagoonAPIError{Message: "Duplicate entry 'mycluster' for key 'name'"}
-		},
-		getDeployTargetByNameFn: func(_ context.Context, _ string) (*client.DeployTarget, error) {
-			return nil, fmt.Errorf("network error")
-		},
-	}
-	ctx := testCtx(mock)
-	r := &DeployTarget{}
-	_, err := r.Create(ctx, infer.CreateRequest[DeployTargetArgs]{
-		Inputs: DeployTargetArgs{Name: "mycluster", ConsoleURL: "https://k8s.example.com"},
-	})
-	if err == nil {
-		t.Fatal("expected error when lookup fails")
-	}
-}

--- a/provider/pkg/resources/project.go
+++ b/provider/pkg/resources/project.go
@@ -84,23 +84,10 @@ func (r *Project) Create(ctx context.Context, req infer.CreateRequest[ProjectArg
 
 	project, err := c.CreateProject(ctx, input)
 	if err != nil {
-		if !client.IsDuplicateEntry(err) {
-			return infer.CreateResponse[ProjectState]{}, fmt.Errorf("failed to create project: %w", err)
+		if client.IsDuplicateEntry(err) {
+			return infer.CreateResponse[ProjectState]{}, fmt.Errorf("project %q already exists: use pulumi import to bring it under management", req.Inputs.Name)
 		}
-
-		// Resource already exists — adopt it by looking up by name and updating
-		existing, lookupErr := c.GetProjectByName(ctx, req.Inputs.Name)
-		if lookupErr != nil {
-			return infer.CreateResponse[ProjectState]{}, fmt.Errorf("project %q already exists but failed to look up: %w", req.Inputs.Name, lookupErr)
-		}
-
-		// Update the existing resource to match desired inputs
-		// Remove name — it's not updatable
-		delete(input, "name")
-		project, err = c.UpdateProject(ctx, existing.ID, input)
-		if err != nil {
-			return infer.CreateResponse[ProjectState]{}, fmt.Errorf("project %q already exists but failed to update: %w", req.Inputs.Name, err)
-		}
+		return infer.CreateResponse[ProjectState]{}, fmt.Errorf("failed to create project: %w", err)
 	}
 
 	return infer.CreateResponse[ProjectState]{

--- a/provider/pkg/resources/project_crud_test.go
+++ b/provider/pkg/resources/project_crud_test.go
@@ -69,41 +69,10 @@ func TestProjectCreate_DryRun(t *testing.T) {
 	}
 }
 
-func TestProjectCreate_DuplicateEntry_Adopts(t *testing.T) {
+func TestProjectCreate_DuplicateEntry_ReturnsError(t *testing.T) {
 	mock := &mockLagoonClient{
 		createProjectFn: func(_ context.Context, _ map[string]any) (*client.Project, error) {
 			return nil, &client.LagoonAPIError{Message: "Duplicate entry"}
-		},
-		getProjectByNameFn: func(_ context.Context, name string) (*client.Project, error) {
-			return &client.Project{ID: 99, Name: name}, nil
-		},
-		updateProjectFn: func(_ context.Context, id int, _ map[string]any) (*client.Project, error) {
-			return &client.Project{ID: id, Name: "myproject", Created: "2024-01-01"}, nil
-		},
-	}
-	ctx := testCtx(mock)
-	r := &Project{}
-	resp, err := r.Create(ctx, infer.CreateRequest[ProjectArgs]{
-		Inputs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", DeploytargetID: 1},
-	})
-	if err != nil {
-		t.Fatalf("Create with duplicate should adopt: %v", err)
-	}
-	if resp.ID != "99" {
-		t.Errorf("expected adopted ID '99', got %q", resp.ID)
-	}
-	if resp.Output.LagoonID != 99 {
-		t.Errorf("expected LagoonID 99, got %d", resp.Output.LagoonID)
-	}
-}
-
-func TestProjectCreate_DuplicateEntry_LookupFails(t *testing.T) {
-	mock := &mockLagoonClient{
-		createProjectFn: func(_ context.Context, _ map[string]any) (*client.Project, error) {
-			return nil, &client.LagoonAPIError{Message: "Duplicate entry"}
-		},
-		getProjectByNameFn: func(_ context.Context, _ string) (*client.Project, error) {
-			return nil, fmt.Errorf("network error")
 		},
 	}
 	ctx := testCtx(mock)
@@ -112,7 +81,13 @@ func TestProjectCreate_DuplicateEntry_LookupFails(t *testing.T) {
 		Inputs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", DeploytargetID: 1},
 	})
 	if err == nil {
-		t.Fatal("expected error when lookup fails")
+		t.Fatal("expected error when project already exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pulumi import") {
+		t.Errorf("expected 'pulumi import' hint in error, got: %v", err)
 	}
 }
 
@@ -361,31 +336,6 @@ func TestProjectRead_InvalidID(t *testing.T) {
 	_, err := r.Read(ctx, infer.ReadRequest[ProjectArgs, ProjectState]{ID: "not-a-number"})
 	if err == nil {
 		t.Fatal("expected error for non-numeric ID")
-	}
-}
-
-func TestProjectCreate_DuplicateAdopt_UpdateFails(t *testing.T) {
-	mock := &mockLagoonClient{
-		createProjectFn: func(_ context.Context, _ map[string]any) (*client.Project, error) {
-			return nil, &client.LagoonAPIError{Message: "Duplicate entry 'myproject' for key 'name'"}
-		},
-		getProjectByNameFn: func(_ context.Context, name string) (*client.Project, error) {
-			return &client.Project{ID: 99, Name: name}, nil
-		},
-		updateProjectFn: func(_ context.Context, _ int, _ map[string]any) (*client.Project, error) {
-			return nil, fmt.Errorf("update failed")
-		},
-	}
-	ctx := testCtx(mock)
-	r := &Project{}
-	_, err := r.Create(ctx, infer.CreateRequest[ProjectArgs]{
-		Inputs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", DeploytargetID: 1},
-	})
-	if err == nil {
-		t.Fatal("expected error when adopt-update fails")
-	}
-	if !strings.Contains(err.Error(), "failed to update") {
-		t.Errorf("expected error to mention update failure, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Project.Create` and `DeployTarget.Create` were silently adopting existing resources when the API returned a duplicate-key error: they would look up the resource by name, apply desired inputs as an update, and return success as if the resource had just been created
- This behavior is surprising and dangerous: a `pulumi up` against a resource that exists outside Pulumi state should fail, not silently take ownership
- The correct recovery path is `pulumi import`, which explicitly brings an existing resource under Pulumi management

**Breaking change:** stacks that relied on implicit adoption must now run `pulumi import` instead.

## Changes

- `project.go`: duplicate-key error now returns an explicit error with a `pulumi import` hint
- `deploytarget.go`: same
- Tests: removed the three adoption test cases; replaced with a single test per resource type that verifies the error message and hint

Closes #199

## Test plan

- [ ] `TestProjectCreate_DuplicateEntry_ReturnsError`: verifies duplicate creates return an error containing "already exists" and "pulumi import"
- [ ] `TestDeployTargetCreate_DuplicateReturnsError`: same for deploy targets
- [ ] All other project and deploy target tests continue to pass
- [ ] Full test suite: `make go-test`