### PR TITLE
feat(client): improve retry policy with 429 support, Retry-After, and jitter

### DIFF
--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -25,6 +27,7 @@ type Client struct {
 	// Retry configuration
 	maxRetries int
 	baseDelay  time.Duration
+	maxDelay   time.Duration
 
 	// Token refresh
 	tokenFunc  func() (string, error) // optional: generates a fresh token
@@ -73,6 +76,7 @@ func NewClient(apiURL, token string, opts ...ClientOption) *Client {
 		verifySSL:  true,
 		maxRetries: 3,
 		baseDelay:  1 * time.Second,
+		maxDelay:   30 * time.Second,
 	}
 
 	for _, opt := range opts {
@@ -115,13 +119,13 @@ func (c *Client) Execute(ctx context.Context, query string, variables map[string
 	}
 
 	var lastErr error
+	var nextDelay time.Duration
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
 		if attempt > 0 {
-			delay := c.baseDelay * time.Duration(math.Pow(2, float64(attempt-1)))
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(delay):
+			case <-time.After(nextDelay):
 			}
 		}
 
@@ -130,16 +134,40 @@ func (c *Client) Execute(ctx context.Context, query string, variables map[string
 			return data, nil
 		}
 
-		// Only retry on connection/transport errors, not API errors
+		// Retry on rate limit errors, honoring the Retry-After header.
+		var rlErr *LagoonRateLimitError
+		if errors.As(err, &rlErr) {
+			lastErr = err
+			nextDelay = c.retryDelay(attempt+1, rlErr.RetryAfter)
+			continue
+		}
+		// Retry on connection/transport errors with jittered exponential backoff.
 		var connErr *LagoonConnectionError
 		if isConnectionError(err, &connErr) {
 			lastErr = err
+			nextDelay = c.retryDelay(attempt+1, 0)
 			continue
 		}
 		return nil, err
 	}
 
 	return nil, lastErr
+}
+
+// retryDelay returns the wait duration for a retry attempt.
+// minDelay overrides the backoff when set (e.g. from a Retry-After header).
+func (c *Client) retryDelay(attempt int, minDelay time.Duration) time.Duration {
+	exp := c.baseDelay * time.Duration(math.Pow(2, float64(attempt-1)))
+	if exp > c.maxDelay {
+		exp = c.maxDelay
+	}
+	// Add up to 25% jitter so concurrent retries don't all fire at once.
+	jitter := time.Duration(rand.Int63n(int64(exp) / 4)) //nolint:gosec // non-crypto jitter
+	delay := exp + jitter
+	if minDelay > delay {
+		delay = minDelay
+	}
+	return delay
 }
 
 func isConnectionError(err error, target **LagoonConnectionError) bool {
@@ -195,6 +223,15 @@ func (c *Client) executeOnce(ctx context.Context, query string, variables map[st
 		return nil, &LagoonConnectionError{Message: "failed to read response body", Cause: err}
 	}
 
+	if resp.StatusCode == 429 {
+		var retryAfter time.Duration
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
+				retryAfter = time.Duration(secs) * time.Second
+			}
+		}
+		return nil, &LagoonRateLimitError{RetryAfter: retryAfter}
+	}
 	if resp.StatusCode >= 500 {
 		return nil, &LagoonConnectionError{
 			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(respBody)),

--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -162,7 +162,11 @@ func (c *Client) retryDelay(attempt int, minDelay time.Duration) time.Duration {
 		exp = c.maxDelay
 	}
 	// Add up to 25% jitter so concurrent retries don't all fire at once.
-	jitter := time.Duration(rand.Int63n(int64(exp) / 4)) //nolint:gosec // non-crypto jitter
+	// Guard against exp==0 (e.g. baseDelay unset) to avoid rand.Int63n(0) panic.
+	var jitter time.Duration
+	if exp > 0 {
+		jitter = time.Duration(rand.Int63n(int64(exp) / 4)) //nolint:gosec // non-crypto jitter
+	}
 	delay := exp + jitter
 	if minDelay > delay {
 		delay = minDelay
@@ -229,6 +233,8 @@ func (c *Client) executeOnce(ctx context.Context, query string, variables map[st
 			if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
 				retryAfter = time.Duration(secs) * time.Second
 			}
+			// Non-integer Retry-After values (e.g. HTTP-date, fractional seconds) are
+			// silently ignored; retryAfter stays 0 and backoff uses the exponential default.
 		}
 		return nil, &LagoonRateLimitError{RetryAfter: retryAfter}
 	}

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -152,6 +152,96 @@ func TestExecute_NoRetryOnAPIError(t *testing.T) {
 	}
 }
 
+func TestExecute_RetryOn429_Succeeds(t *testing.T) {
+	var attempts int32
+	server := mockGraphQLServerRaw(t, func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		resp := map[string]any{"data": map[string]any{"ok": true}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	c := NewClient(server.URL, "token", WithMaxRetries(3))
+	c.baseDelay = 1 * time.Millisecond
+	c.maxDelay = 1 * time.Millisecond
+	data, err := c.Execute(context.Background(), "query { ok }", nil)
+	if err != nil {
+		t.Fatalf("expected success after 429 retries, got: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected non-nil data")
+	}
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Errorf("expected 3 attempts, got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestExecute_ExhaustedRetries_Returns429Error(t *testing.T) {
+	server := mockGraphQLServerRaw(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+	defer server.Close()
+
+	c := NewClient(server.URL, "token", WithMaxRetries(2))
+	c.baseDelay = 1 * time.Millisecond
+	c.maxDelay = 1 * time.Millisecond
+	_, err := c.Execute(context.Background(), "query { ok }", nil)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !errors.Is(err, ErrRateLimit) {
+		t.Errorf("expected ErrRateLimit, got: %v", err)
+	}
+}
+
+func TestExecute_RetryAfterHeader_Honored(t *testing.T) {
+	var attempts int32
+	server := mockGraphQLServerRaw(t, func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 1 {
+			w.Header().Set("Retry-After", "1") // 1 second
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		resp := map[string]any{"data": map[string]any{"ok": true}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	c := NewClient(server.URL, "token", WithMaxRetries(2))
+	c.baseDelay = 1 * time.Millisecond
+	c.maxDelay = 1 * time.Millisecond
+	start := time.Now()
+	data, err := c.Execute(context.Background(), "query { ok }", nil)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("expected success: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected non-nil data")
+	}
+	// Retry-After: 1 means wait at least 1 second
+	if elapsed < 1*time.Second {
+		t.Errorf("expected at least 1s wait for Retry-After, got %v", elapsed)
+	}
+}
+
+func TestRetryDelay_CappedAtMaxDelay(t *testing.T) {
+	c := &Client{baseDelay: 1 * time.Second, maxDelay: 5 * time.Second}
+	// At attempt 10, uncapped exponential would be 512s. It should be capped at 5s (plus jitter).
+	delay := c.retryDelay(10, 0)
+	if delay > 7*time.Second { // 5s + 25% jitter headroom
+		t.Errorf("expected delay capped near maxDelay (5s), got %v", delay)
+	}
+}
+
 func TestExecute_ContextCancellation(t *testing.T) {
 	server := mockGraphQLServerRaw(t, func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(5 * time.Second)

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -626,3 +626,12 @@ func TestHTTP4xxReturnsAPIError(t *testing.T) {
 		t.Error("HTTP 400 should NOT be a LagoonConnectionError")
 	}
 }
+
+func TestRetryDelay_ZeroBaseDelay_NoPanic(t *testing.T) {
+	// rand.Int63n(0) panics; guard must prevent that when exp is zero.
+	c := &Client{baseDelay: 0, maxDelay: 30 * time.Second}
+	delay := c.retryDelay(1, 0)
+	if delay != 0 {
+		t.Errorf("expected 0 delay with zero baseDelay, got %v", delay)
+	}
+}

--- a/provider/pkg/client/errors.go
+++ b/provider/pkg/client/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // LagoonAPIError represents an error returned by the Lagoon GraphQL API.
@@ -61,6 +62,19 @@ func (e *LagoonValidationError) Error() string {
 	return msg
 }
 
+// LagoonRateLimitError represents an HTTP 429 Too Many Requests response.
+// It is retryable; RetryAfter indicates the minimum wait before the next attempt.
+type LagoonRateLimitError struct {
+	RetryAfter time.Duration
+}
+
+func (e *LagoonRateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("Lagoon rate limit exceeded; retry after %s", e.RetryAfter)
+	}
+	return "Lagoon rate limit exceeded"
+}
+
 // Sentinel errors for errors.Is() checking.
 var (
 	ErrAPI            = errors.New("lagoon api error")
@@ -68,6 +82,7 @@ var (
 	ErrNotFound       = errors.New("lagoon resource not found")
 	ErrValidation     = errors.New("lagoon validation error")
 	ErrDuplicateEntry = errors.New("lagoon duplicate entry")
+	ErrRateLimit      = errors.New("lagoon rate limit")
 )
 
 // isDuplicateMessage returns true if a message indicates a duplicate entry.
@@ -115,3 +130,4 @@ func (e *LagoonAPIError) Is(target error) bool {
 func (e *LagoonConnectionError) Is(target error) bool  { return target == ErrConnection }
 func (e *LagoonNotFoundError) Is(target error) bool    { return target == ErrNotFound }
 func (e *LagoonValidationError) Is(target error) bool  { return target == ErrValidation }
+func (e *LagoonRateLimitError) Is(target error) bool   { return target == ErrRateLimit }


### PR DESCRIPTION
## Summary

The retry loop previously only retried `LagoonConnectionError` with deterministic exponential backoff, no maximum delay cap, and no handling for HTTP 429 rate limit responses.

Changes:
- **HTTP 429 support**: `executeOnce` now returns a new `LagoonRateLimitError` for 429 responses (retryable), parsed from the `Retry-After` response header when present
- **Retry-After honored**: The retry delay uses the `Retry-After` value as a minimum wait, so the client respects server-side rate limit instructions
- **Jitter**: Up to 25% of the capped backoff duration is added as random jitter to spread concurrent retries from large stacks
- **Max delay cap**: Backoff is capped at 30 seconds to bound total retry time
- **Unified delay logic**: A single `nextDelay` variable is computed after each retryable failure and consumed at the start of the next attempt (eliminates the previous double-sleep edge case)
- **No config knobs**: All retry parameters are hardcoded defaults; no new provider config fields
- **Panic guard**: `retryDelay` now guards against `rand.Int63n(0)` when `baseDelay` is zero

Closes #207

## Test plan

- [x] `TestExecute_RetryOn429_Succeeds`: verifies 429 responses are retried and succeed on the third attempt
- [x] `TestExecute_ExhaustedRetries_Returns429Error`: verifies exhausted retries return `ErrRateLimit`
- [x] `TestExecute_RetryAfterHeader_Honored`: verifies the client waits at least `Retry-After` seconds before retrying
- [x] `TestRetryDelay_CappedAtMaxDelay`: verifies high-attempt delays are capped at `maxDelay`
- [x] `TestRetryDelay_ZeroBaseDelay_NoPanic`: verifies no panic when baseDelay is zero
- [x] All existing retry and connection tests continue to pass
- [x] Full test suite: `make go-test`