### PR TITLE
feat(resources): add local input validation for variable scope, task permission/arg type, and route list limits

### DIFF
--- a/provider/pkg/resources/route.go
+++ b/provider/pkg/resources/route.go
@@ -113,6 +113,9 @@ func (r *Route) Create(ctx context.Context, req infer.CreateRequest[RouteArgs]) 
 	if err := validateRouteEnums(args.Insecure, args.RouteType); err != nil {
 		return infer.CreateResponse[RouteState]{}, err
 	}
+	if err := validateRouteListLimits(args); err != nil {
+		return infer.CreateResponse[RouteState]{}, err
+	}
 
 	input := map[string]any{
 		"project": args.ProjectName,
@@ -207,6 +210,9 @@ func (r *Route) Update(ctx context.Context, req infer.UpdateRequest[RouteArgs, R
 	state := req.State
 
 	if err := validateRouteEnums(args.Insecure, args.RouteType); err != nil {
+		return infer.UpdateResponse[RouteState]{}, err
+	}
+	if err := validateRouteListLimits(args); err != nil {
 		return infer.UpdateResponse[RouteState]{}, err
 	}
 

--- a/provider/pkg/resources/route_crud_test.go
+++ b/provider/pkg/resources/route_crud_test.go
@@ -674,3 +674,49 @@ func TestRouteDiff_NoChanges(t *testing.T) {
 		t.Errorf("expected no changes, got: %v", resp.DetailedDiff)
 	}
 }
+
+func TestRouteCreate_TooManyAnnotations_ReturnsError(t *testing.T) {
+	anns := make([]RouteAnnotationInput, 11)
+	for i := range anns {
+		anns[i] = RouteAnnotationInput{Key: "k", Value: "v"}
+	}
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Route{}
+	_, err := r.Create(ctx, infer.CreateRequest[RouteArgs]{
+		Inputs: RouteArgs{ProjectName: "proj", Domain: "ex.com", Annotations: &anns},
+	})
+	if err == nil {
+		t.Fatal("expected error for >10 annotations, got nil")
+	}
+}
+
+func TestRouteCreate_TooManyAlternativeNames_ReturnsError(t *testing.T) {
+	names := make([]string, 26)
+	for i := range names {
+		names[i] = "alt.example.com"
+	}
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Route{}
+	_, err := r.Create(ctx, infer.CreateRequest[RouteArgs]{
+		Inputs: RouteArgs{ProjectName: "proj", Domain: "ex.com", AlternativeNames: &names},
+	})
+	if err == nil {
+		t.Fatal("expected error for >25 alternativeNames, got nil")
+	}
+}
+
+func TestRouteUpdate_TooManyPathRoutes_ReturnsError(t *testing.T) {
+	prs := make([]RoutePathRouteInput, 11)
+	for i := range prs {
+		prs[i] = RoutePathRouteInput{Path: "/", ToService: "svc"}
+	}
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Route{}
+	_, err := r.Update(ctx, infer.UpdateRequest[RouteArgs, RouteState]{
+		Inputs: RouteArgs{ProjectName: "proj", Domain: "ex.com", PathRoutes: &prs},
+		State:  RouteState{RouteArgs: RouteArgs{ProjectName: "proj", Domain: "ex.com"}, LagoonID: 1},
+	})
+	if err == nil {
+		t.Fatal("expected error for >10 pathRoutes on update, got nil")
+	}
+}

--- a/provider/pkg/resources/task.go
+++ b/provider/pkg/resources/task.go
@@ -89,6 +89,19 @@ func (r *Task) Create(ctx context.Context, req infer.CreateRequest[TaskArgs]) (i
 		return infer.CreateResponse[TaskState]{}, fmt.Errorf("unknown task type %q: must be 'command' or 'image'", req.Inputs.Type)
 	}
 
+	if req.Inputs.Permission != nil {
+		if err := validateTaskPermission(*req.Inputs.Permission); err != nil {
+			return infer.CreateResponse[TaskState]{}, err
+		}
+	}
+	if req.Inputs.Arguments != nil {
+		for i, arg := range *req.Inputs.Arguments {
+			if err := validateTaskArgType(arg.Type); err != nil {
+				return infer.CreateResponse[TaskState]{}, fmt.Errorf("arguments[%d]: %w", i, err)
+			}
+		}
+	}
+
 	input := map[string]any{
 		"name":    req.Inputs.Name,
 		"type":    strings.ToUpper(req.Inputs.Type),

--- a/provider/pkg/resources/task_crud_test.go
+++ b/provider/pkg/resources/task_crud_test.go
@@ -386,3 +386,29 @@ func TestTaskRead_APIError(t *testing.T) {
 		t.Fatal("expected error when read API fails")
 	}
 }
+
+func TestTaskCreate_InvalidPermission_ReturnsError(t *testing.T) {
+	cmd := "drush cr"
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Task{}
+	perm := "admin"
+	_, err := r.Create(ctx, infer.CreateRequest[TaskArgs]{
+		Inputs: TaskArgs{Name: "t", Type: "command", Service: "cli", Command: &cmd, Permission: &perm},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid permission, got nil")
+	}
+}
+
+func TestTaskCreate_InvalidArgType_ReturnsError(t *testing.T) {
+	cmd := "drush cr"
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Task{}
+	args := []TaskArgumentInput{{Name: "env", DisplayName: "Env", Type: "bad_type"}}
+	_, err := r.Create(ctx, infer.CreateRequest[TaskArgs]{
+		Inputs: TaskArgs{Name: "t", Type: "command", Service: "cli", Command: &cmd, Arguments: &args},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid argument type, got nil")
+	}
+}

--- a/provider/pkg/resources/validate.go
+++ b/provider/pkg/resources/validate.go
@@ -1,0 +1,72 @@
+package resources
+
+import (
+	"fmt"
+	"strings"
+)
+
+var validVariableScopes = map[string]bool{
+	"build":                         true,
+	"runtime":                       true,
+	"global":                        true,
+	"container_registry":            true,
+	"internal_container_registry":   true,
+}
+
+var validTaskPermissions = map[string]bool{
+	"guest":      true,
+	"developer":  true,
+	"maintainer": true,
+}
+
+var validTaskArgTypes = map[string]bool{
+	"string":                            true,
+	"environment_source_name":           true,
+	"environment_source_name_exclude_self": true,
+}
+
+// validateVariableScope returns an error if scope is not one of the accepted values.
+func validateVariableScope(scope string) error {
+	if !validVariableScopes[strings.ToLower(scope)] {
+		return fmt.Errorf("invalid variable scope %q: must be one of build, runtime, global, container_registry, internal_container_registry", scope)
+	}
+	return nil
+}
+
+// validateTaskPermission returns an error if permission is not one of the accepted values.
+func validateTaskPermission(permission string) error {
+	if !validTaskPermissions[strings.ToLower(permission)] {
+		return fmt.Errorf("invalid task permission %q: must be one of guest, developer, maintainer", permission)
+	}
+	return nil
+}
+
+// validateTaskArgType returns an error if the argument type is not one of the accepted values.
+func validateTaskArgType(argType string) error {
+	if !validTaskArgTypes[strings.ToLower(argType)] {
+		return fmt.Errorf("invalid task argument type %q: must be one of STRING, ENVIRONMENT_SOURCE_NAME, ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF", argType)
+	}
+	return nil
+}
+
+// validatePositiveID returns an error if id is not positive.
+func validatePositiveID(field string, id int) error {
+	if id <= 0 {
+		return fmt.Errorf("%s must be a positive integer, got %d", field, id)
+	}
+	return nil
+}
+
+// validateRouteListLimits checks annotation, alternativeNames, and pathRoute counts.
+func validateRouteListLimits(args RouteArgs) error {
+	if args.Annotations != nil && len(*args.Annotations) > 10 {
+		return fmt.Errorf("annotations exceeds maximum of 10 entries (got %d)", len(*args.Annotations))
+	}
+	if args.AlternativeNames != nil && len(*args.AlternativeNames) > 25 {
+		return fmt.Errorf("alternativeNames exceeds maximum of 25 entries (got %d)", len(*args.AlternativeNames))
+	}
+	if args.PathRoutes != nil && len(*args.PathRoutes) > 10 {
+		return fmt.Errorf("pathRoutes exceeds maximum of 10 entries (got %d)", len(*args.PathRoutes))
+	}
+	return nil
+}

--- a/provider/pkg/resources/validate_test.go
+++ b/provider/pkg/resources/validate_test.go
@@ -1,0 +1,146 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateVariableScope(t *testing.T) {
+	valid := []string{
+		"build", "runtime", "global",
+		"container_registry", "internal_container_registry",
+		"BUILD", "Runtime", "GLOBAL",
+	}
+	for _, s := range valid {
+		if err := validateVariableScope(s); err != nil {
+			t.Errorf("scope %q should be valid, got error: %v", s, err)
+		}
+	}
+
+	invalid := []string{"", "staging", "production", "dev"}
+	for _, s := range invalid {
+		if err := validateVariableScope(s); err == nil {
+			t.Errorf("scope %q should be invalid, got no error", s)
+		}
+	}
+}
+
+func TestValidateTaskPermission(t *testing.T) {
+	valid := []string{"guest", "developer", "maintainer", "GUEST", "Developer"}
+	for _, p := range valid {
+		if err := validateTaskPermission(p); err != nil {
+			t.Errorf("permission %q should be valid, got error: %v", p, err)
+		}
+	}
+
+	invalid := []string{"", "admin", "owner", "viewer"}
+	for _, p := range invalid {
+		if err := validateTaskPermission(p); err == nil {
+			t.Errorf("permission %q should be invalid, got no error", p)
+		}
+	}
+}
+
+func TestValidateTaskArgType(t *testing.T) {
+	valid := []string{
+		"string", "STRING",
+		"environment_source_name", "ENVIRONMENT_SOURCE_NAME",
+		"environment_source_name_exclude_self", "ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF",
+	}
+	for _, typ := range valid {
+		if err := validateTaskArgType(typ); err != nil {
+			t.Errorf("arg type %q should be valid, got error: %v", typ, err)
+		}
+	}
+
+	invalid := []string{"", "int", "bool", "number"}
+	for _, typ := range invalid {
+		if err := validateTaskArgType(typ); err == nil {
+			t.Errorf("arg type %q should be invalid, got no error", typ)
+		}
+	}
+}
+
+func TestValidatePositiveID(t *testing.T) {
+	if err := validatePositiveID("projectId", 1); err != nil {
+		t.Errorf("ID=1 should be valid, got: %v", err)
+	}
+	if err := validatePositiveID("projectId", 100); err != nil {
+		t.Errorf("ID=100 should be valid, got: %v", err)
+	}
+
+	if err := validatePositiveID("projectId", 0); err == nil {
+		t.Error("ID=0 should be invalid, got no error")
+	}
+	if err := validatePositiveID("projectId", -1); err == nil {
+		t.Error("ID=-1 should be invalid, got no error")
+	}
+}
+
+func TestValidateRouteListLimits(t *testing.T) {
+	makeStrings := func(n int) []string {
+		s := make([]string, n)
+		for i := range s {
+			s[i] = "item"
+		}
+		return s
+	}
+	makeAnnotations := func(n int) []RouteAnnotationInput {
+		a := make([]RouteAnnotationInput, n)
+		for i := range a {
+			a[i] = RouteAnnotationInput{Key: "k", Value: "v"}
+		}
+		return a
+	}
+	makePathRoutes := func(n int) []RoutePathRouteInput {
+		r := make([]RoutePathRouteInput, n)
+		for i := range r {
+			r[i] = RoutePathRouteInput{Path: "/", ToService: "svc"}
+		}
+		return r
+	}
+
+	// Valid counts
+	ann10 := makeAnnotations(10)
+	alt25 := makeStrings(25)
+	pr10 := makePathRoutes(10)
+	args := RouteArgs{
+		ProjectName:      "proj",
+		Domain:           "example.com",
+		Annotations:      &ann10,
+		AlternativeNames: &alt25,
+		PathRoutes:       &pr10,
+	}
+	if err := validateRouteListLimits(args); err != nil {
+		t.Errorf("at-limit counts should be valid, got: %v", err)
+	}
+
+	// Over-limit annotations
+	ann11 := makeAnnotations(11)
+	args.Annotations = &ann11
+	if err := validateRouteListLimits(args); err == nil {
+		t.Error("11 annotations should be invalid, got no error")
+	} else if !strings.Contains(err.Error(), "annotations") {
+		t.Errorf("error should mention 'annotations', got: %v", err)
+	}
+
+	// Over-limit alternativeNames
+	args.Annotations = &ann10
+	alt26 := makeStrings(26)
+	args.AlternativeNames = &alt26
+	if err := validateRouteListLimits(args); err == nil {
+		t.Error("26 alternativeNames should be invalid, got no error")
+	} else if !strings.Contains(err.Error(), "alternativeNames") {
+		t.Errorf("error should mention 'alternativeNames', got: %v", err)
+	}
+
+	// Over-limit pathRoutes
+	args.AlternativeNames = &alt25
+	pr11 := makePathRoutes(11)
+	args.PathRoutes = &pr11
+	if err := validateRouteListLimits(args); err == nil {
+		t.Error("11 pathRoutes should be invalid, got no error")
+	} else if !strings.Contains(err.Error(), "pathRoutes") {
+		t.Errorf("error should mention 'pathRoutes', got: %v", err)
+	}
+}

--- a/provider/pkg/resources/variable.go
+++ b/provider/pkg/resources/variable.go
@@ -48,6 +48,12 @@ func (s *VariableState) Annotate(a infer.Annotator) {
 }
 
 func (r *Variable) Create(ctx context.Context, req infer.CreateRequest[VariableArgs]) (infer.CreateResponse[VariableState], error) {
+	if err := validateVariableScope(req.Inputs.Scope); err != nil {
+		return infer.CreateResponse[VariableState]{}, err
+	}
+	if err := validatePositiveID("projectId", req.Inputs.ProjectID); err != nil {
+		return infer.CreateResponse[VariableState]{}, err
+	}
 	client := clientFor(ctx)
 
 	if req.DryRun {
@@ -72,6 +78,12 @@ func (r *Variable) Create(ctx context.Context, req infer.CreateRequest[VariableA
 }
 
 func (r *Variable) Update(ctx context.Context, req infer.UpdateRequest[VariableArgs, VariableState]) (infer.UpdateResponse[VariableState], error) {
+	if err := validateVariableScope(req.Inputs.Scope); err != nil {
+		return infer.UpdateResponse[VariableState]{}, err
+	}
+	if err := validatePositiveID("projectId", req.Inputs.ProjectID); err != nil {
+		return infer.UpdateResponse[VariableState]{}, err
+	}
 	client := clientFor(ctx)
 
 	if req.DryRun {

--- a/provider/pkg/resources/variable_crud_test.go
+++ b/provider/pkg/resources/variable_crud_test.go
@@ -317,6 +317,40 @@ func TestVariableUpdate_APIError(t *testing.T) {
 	}
 }
 
+func TestVariableCreate_InvalidScope_ReturnsError(t *testing.T) {
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Variable{}
+	_, err := r.Create(ctx, infer.CreateRequest[VariableArgs]{
+		Inputs: VariableArgs{Name: "V", Value: "x", ProjectID: 1, Scope: "invalid_scope"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid scope, got nil")
+	}
+}
+
+func TestVariableCreate_ZeroProjectID_ReturnsError(t *testing.T) {
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Variable{}
+	_, err := r.Create(ctx, infer.CreateRequest[VariableArgs]{
+		Inputs: VariableArgs{Name: "V", Value: "x", ProjectID: 0, Scope: "build"},
+	})
+	if err == nil {
+		t.Fatal("expected error for zero projectId, got nil")
+	}
+}
+
+func TestVariableUpdate_InvalidScope_ReturnsError(t *testing.T) {
+	ctx := testCtx(&mockLagoonClient{})
+	r := &Variable{}
+	_, err := r.Update(ctx, infer.UpdateRequest[VariableArgs, VariableState]{
+		Inputs: VariableArgs{Name: "V", Value: "x", ProjectID: 1, Scope: "bad_scope"},
+		State:  VariableState{VariableArgs: VariableArgs{Name: "V", Value: "old", ProjectID: 1, Scope: "build"}, LagoonID: 1},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid scope on update, got nil")
+	}
+}
+
 func TestVariableRead_RefreshFromState(t *testing.T) {
 	mock := &mockLagoonClient{
 		getVariableFn: func(_ context.Context, name string, _ int, _ *int) (*client.Variable, error) {


### PR DESCRIPTION
## Summary

Input validation was uneven: some enums were validated locally, but most fields were left to fail at the Lagoon API with slower and less actionable errors. This PR adds consistent local validation that fires at `pulumi preview` time.

Changes:
- **`variable` scope**: validates against the five accepted values (`build`, `runtime`, `global`, `container_registry`, `internal_container_registry`) in Create and Update; also validates `projectId > 0`
- **`task` permission**: validates against `guest`, `developer`, `maintainer` in Create (task has no Update — it's replace-on-change)
- **`task` argument type**: validates each argument's `type` field against `STRING`, `ENVIRONMENT_SOURCE_NAME`, `ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF` in Create
- **`route` list limits**: enforces the already-documented limits (annotations max 10, alternativeNames max 25, pathRoutes max 10) in Create and Update

All validation logic lives in a new `validate.go` with a `validate_test.go` covering happy and error paths. CRUD test files have added cases that confirm invalid inputs return errors without making any API calls.

Closes #209

## Test plan

- [ ] `TestValidateVariableScope`: all five valid scopes accepted, invalid rejected
- [ ] `TestValidateTaskPermission`: guest/developer/maintainer accepted, others rejected
- [ ] `TestValidateTaskArgType`: three valid arg types accepted, others rejected
- [ ] `TestValidatePositiveID`: positive IDs accepted, zero and negative rejected
- [ ] `TestValidateRouteListLimits`: at-limit counts accepted, over-limit rejected with field name in message
- [ ] `TestVariableCreate_InvalidScope_ReturnsError`: invalid scope rejected on Create
- [ ] `TestVariableCreate_ZeroProjectID_ReturnsError`: zero projectId rejected on Create
- [ ] `TestVariableUpdate_InvalidScope_ReturnsError`: invalid scope rejected on Update
- [ ] `TestTaskCreate_InvalidPermission_ReturnsError`: invalid permission rejected on Create
- [ ] `TestTaskCreate_InvalidArgType_ReturnsError`: invalid arg type rejected on Create
- [ ] `TestRouteCreate_TooManyAnnotations_ReturnsError`: >10 annotations rejected on Create
- [ ] `TestRouteCreate_TooManyAlternativeNames_ReturnsError`: >25 alternativeNames rejected on Create
- [ ] `TestRouteUpdate_TooManyPathRoutes_ReturnsError`: >10 pathRoutes rejected on Update
- [ ] Full test suite: `make go-test`