### PR TITLE
docs(client): document broad-list query gaps with TODO(#201) markers

### DIFF
--- a/provider/pkg/client/deploytarget.go
+++ b/provider/pkg/client/deploytarget.go
@@ -36,6 +36,10 @@ func (c *Client) CreateDeployTarget(ctx context.Context, input map[string]any) (
 }
 
 // GetDeployTargetByID retrieves a deploy target by ID (queries all and filters).
+//
+// TODO(#201): The Lagoon GraphQL API does not expose a `kubernetesById` query as of
+// v2.30. When one becomes available, replace the allKubernetes scan with a targeted
+// call. Until then, this fetches all deploy targets and filters client-side.
 func (c *Client) GetDeployTargetByID(ctx context.Context, id int) (*DeployTarget, error) {
 	targets, err := c.GetAllDeployTargets(ctx)
 	if err != nil {
@@ -62,6 +66,9 @@ func (c *Client) GetDeployTargetByID(ctx context.Context, id int) (*DeployTarget
 }
 
 // GetDeployTargetByName retrieves a deploy target by name.
+//
+// TODO(#201): Same broad-list limitation as GetDeployTargetByID. Shares the
+// allKubernetes scan; see that function for the tracked improvement.
 func (c *Client) GetDeployTargetByName(ctx context.Context, name string) (*DeployTarget, error) {
 	targets, err := c.GetAllDeployTargets(ctx)
 	if err != nil {

--- a/provider/pkg/client/group.go
+++ b/provider/pkg/client/group.go
@@ -36,6 +36,14 @@ func (c *Client) CreateGroup(ctx context.Context, name string, parentGroupName *
 }
 
 // GetGroupByName retrieves a group by name.
+//
+// TODO(#201): The Lagoon GraphQL API does not expose a `groupByName` query as of
+// v2.30. When one becomes available, replace the allGroups scan with a targeted
+// call:
+//
+//	query GroupByName($name: String!) { groupByName(name: $name) { id name } }
+//
+// Until then, this fetches all groups and filters client-side.
 func (c *Client) GetGroupByName(ctx context.Context, name string) (*Group, error) {
 	data, err := c.Execute(ctx, queryAllGroups, nil)
 	if err != nil {

--- a/provider/pkg/client/notification.go
+++ b/provider/pkg/client/notification.go
@@ -63,6 +63,12 @@ var (
 )
 
 // getAllNotifications retrieves all notifications of all types.
+//
+// TODO(#201): The Lagoon GraphQL API does not expose per-type targeted notification
+// lookup queries (e.g. `notificationSlackByName`) as of v2.30. All notification
+// reads go through this broad allNotifications fetch and filter client-side.
+// When targeted queries become available, getNotificationByName should call them
+// directly instead.
 func (c *Client) getAllNotifications(ctx context.Context) ([]Notification, error) {
 	data, err := c.Execute(ctx, queryAllNotifications, nil)
 	if err != nil {

--- a/provider/pkg/client/project.go
+++ b/provider/pkg/client/project.go
@@ -102,6 +102,15 @@ func (c *Client) GetProjectByName(ctx context.Context, name string) (*Project, e
 }
 
 // GetProjectByID retrieves a project by ID (queries all projects and filters).
+//
+// TODO(#201): The Lagoon GraphQL API does not expose a `projectById` query as of
+// v2.30. When one becomes available, replace the allProjects scan with a targeted
+// call:
+//
+//	query ProjectById($id: Int!) { projectById(id: $id) { id name gitUrl ... } }
+//
+// Until then, this fetches all projects and filters client-side. On large
+// installations (hundreds of projects) this is measurably slow.
 func (c *Client) GetProjectByID(ctx context.Context, projectID int) (*Project, error) {
 	data, err := c.Execute(ctx, queryAllProjects, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary

Several read operations in the GraphQL client fetch all resources and filter client-side because the Lagoon API (as of v2.30) does not expose targeted lookup queries for:

- `GetProjectByID` — uses `allProjects` (no `projectById` query available)
- `GetDeployTargetByID` / `GetDeployTargetByName` — use `allKubernetes` (no `kubernetesById` / `kubernetesByName` query available)
- `GetGroupByName` — uses `allGroups` (no `groupByName` query available)
- `getAllNotifications` / `getNotificationByName` — use `allNotifications` (no per-type targeted lookup available)

This PR adds `TODO(#201)` comments on each affected function documenting the gap, what a targeted query would look like when the Lagoon API exposes one, and the scale impact. No behavior changes.

The decision was to document the gaps rather than introduce a synthetic client-side cache, since a cache would add complexity and invalidation risk without solving the root cause.

Closes #201

## Test plan

- [ ] No behavior changes: existing test suite passes unchanged (`make go-test`)
- [ ] Comments accurately describe the missing API queries
- [ ] `TODO(#201)` markers are present on all four affected functions