### PR TITLE
fix(config): remove secret annotation from apiUrl provider config

### DIFF
--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -19,7 +19,7 @@ import (
 // All resources access this via infer.GetConfig[LagoonConfig](ctx).
 type LagoonConfig struct {
 	// APIUrl is the Lagoon GraphQL API endpoint.
-	APIUrl string `pulumi:"apiUrl,optional" provider:"secret"`
+	APIUrl string `pulumi:"apiUrl,optional"`
 
 	// Token is a pre-configured JWT authentication token.
 	Token string `pulumi:"token,optional" provider:"secret"`

--- a/provider/schema.json
+++ b/provider/schema.json
@@ -54,8 +54,7 @@
           "environment": [
             "LAGOON_API_URL"
           ]
-        },
-        "secret": true
+        }
       },
       "insecure": {
         "type": "boolean",
@@ -189,8 +188,7 @@
           "environment": [
             "LAGOON_API_URL"
           ]
-        },
-        "secret": true
+        }
       },
       "insecure": {
         "type": "boolean",
@@ -242,8 +240,7 @@
           "environment": [
             "LAGOON_API_URL"
           ]
-        },
-        "secret": true
+        }
       },
       "insecure": {
         "type": "boolean",

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -58,7 +58,6 @@ namespace Tag1Consulting.Lagoon
                 PluginDownloadURL = "github://api.github.com/tag1consulting/pulumi-lagoon-provider",
                 AdditionalSecretOutputs =
                 {
-                    "apiUrl",
                     "jwtSecret",
                     "token",
                 },
@@ -72,21 +71,11 @@ namespace Tag1Consulting.Lagoon
 
     public sealed class ProviderArgs : global::Pulumi.ResourceArgs
     {
-        [Input("apiUrl")]
-        private Input<string>? _apiUrl;
-
         /// <summary>
         /// The Lagoon GraphQL API endpoint URL.
         /// </summary>
-        public Input<string>? ApiUrl
-        {
-            get => _apiUrl;
-            set
-            {
-                var emptySecret = Output.CreateSecret(0);
-                _apiUrl = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
-            }
-        }
+        [Input("apiUrl")]
+        public Input<string>? ApiUrl { get; set; }
 
         /// <summary>
         /// Disable SSL certificate verification when connecting to the Lagoon API.

--- a/sdk/go/lagoon/provider.go
+++ b/sdk/go/lagoon/provider.go
@@ -56,9 +56,6 @@ func NewProvider(ctx *pulumi.Context,
 			args.Token = pulumi.StringPtr(d.(string))
 		}
 	}
-	if args.ApiUrl != nil {
-		args.ApiUrl = pulumi.ToSecret(args.ApiUrl).(pulumi.StringPtrInput)
-	}
 	if args.JwtSecret != nil {
 		args.JwtSecret = pulumi.ToSecret(args.JwtSecret).(pulumi.StringPtrInput)
 	}
@@ -66,7 +63,6 @@ func NewProvider(ctx *pulumi.Context,
 		args.Token = pulumi.ToSecret(args.Token).(pulumi.StringPtrInput)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
-		"apiUrl",
 		"jwtSecret",
 		"token",
 	})

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -47,14 +47,14 @@ export class Provider extends pulumi.ProviderResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         {
-            resourceInputs["apiUrl"] = (args?.apiUrl ? pulumi.secret(args.apiUrl) : undefined) ?? (utilities.getEnv("LAGOON_API_URL") || "https://api.lagoon.sh/graphql");
+            resourceInputs["apiUrl"] = (args?.apiUrl) ?? (utilities.getEnv("LAGOON_API_URL") || "https://api.lagoon.sh/graphql");
             resourceInputs["insecure"] = pulumi.output((args?.insecure) ?? (utilities.getEnvBoolean("LAGOON_INSECURE") || false)).apply(JSON.stringify);
             resourceInputs["jwtAudience"] = (args?.jwtAudience) ?? (utilities.getEnv("LAGOON_JWT_AUDIENCE") || "api.dev");
             resourceInputs["jwtSecret"] = (args?.jwtSecret ? pulumi.secret(args.jwtSecret) : undefined) ?? utilities.getEnv("LAGOON_JWT_SECRET");
             resourceInputs["token"] = (args?.token ? pulumi.secret(args.token) : undefined) ?? utilities.getEnv("LAGOON_TOKEN");
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const secretOpts = { additionalSecretOutputs: ["apiUrl", "jwtSecret", "token"] };
+        const secretOpts = { additionalSecretOutputs: ["jwtSecret", "token"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
         super(Provider.__pulumiType, name, resourceInputs, opts);
     }

--- a/sdk/python/pulumi_lagoon/provider.py
+++ b/sdk/python/pulumi_lagoon/provider.py
@@ -178,7 +178,7 @@ class Provider(pulumi.ProviderResource):
 
             if api_url is None:
                 api_url = (_utilities.get_env('LAGOON_API_URL') or 'https://api.lagoon.sh/graphql')
-            __props__.__dict__["api_url"] = None if api_url is None else pulumi.Output.secret(api_url)
+            __props__.__dict__["api_url"] = api_url
             if insecure is None:
                 insecure = (_utilities.get_env_bool('LAGOON_INSECURE') or False)
             __props__.__dict__["insecure"] = pulumi.Output.from_input(insecure).apply(pulumi.runtime.to_json) if insecure is not None else None
@@ -191,7 +191,7 @@ class Provider(pulumi.ProviderResource):
             if token is None:
                 token = _utilities.get_env('LAGOON_TOKEN')
             __props__.__dict__["token"] = None if token is None else pulumi.Output.secret(token)
-        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["apiUrl", "jwtSecret", "token"])
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["jwtSecret", "token"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(Provider, __self__).__init__(
             'lagoon',


### PR DESCRIPTION
## Summary

\`LagoonConfig.APIUrl\` had \`provider:"secret"\` which caused the API endpoint URL to be redacted in \`pulumi preview\` output, config dumps, and stack state. The endpoint URL is not sensitive — it's just a URL — and hiding it makes debugging and auditing harder without any security benefit.

Changes:
- Remove \`provider:"secret"\` from \`APIUrl\` in \`config.go\`
- Regenerate \`schema.json\` (removes \`"secret": true\` from all three \`apiUrl\` occurrences)
- Regenerate all four SDKs (Python, TypeScript, Go, .NET) to remove the secret wrapper from \`apiUrl\`
- \`token\` and \`jwtSecret\` remain secret

Closes #208

## Test plan

- [x] \`make go-test\` passes
- [x] \`schema.json\`: \`apiUrl\` entries no longer contain \`"secret": true\`
- [x] \`schema.json\`: \`token\` and \`jwtSecret\` entries still contain \`"secret": true\`