### PR TITLE
feat(e2e): add local e2e test suite as a release gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@
         multi-cluster-up multi-cluster-down multi-cluster-preview multi-cluster-status multi-cluster-clusters \
         multi-cluster-deploy multi-cluster-verify multi-cluster-port-forwards multi-cluster-port-forwards-all \
         multi-cluster-test-api multi-cluster-test-ui multi-cluster-info \
+        e2e e2e-build e2e-setup e2e-deploy e2e-assert e2e-teardown \
         clean clean-all \
         go-build go-test go-vet go-schema go-sdk-clean go-sdk-python go-sdk-nodejs go-sdk-go go-sdk-dotnet go-sdk-all go-install check-release-version release-prep go-proxy-warmup check-versions check-pulumi-version
 
@@ -321,6 +322,132 @@ multi-cluster-info:
 	@cd $(MULTI_CLUSTER_DIR) && $(MAKE) show-access-info
 
 #==============================================================================
+# E2E Test Suite
+#==============================================================================
+#
+# Runs a full end-to-end test of the provider against a real Lagoon deployment
+# using the multi-cluster example. Expected wall-clock: 45-90 minutes.
+#
+# Quick usage:
+#   make e2e                         # full two-cluster run
+#   E2E_SKIP_NONPROD=1 make e2e      # prod-only smoke run (~half the time)
+#   E2E_KEEP_CLUSTERS_ON_FAILURE=1 make e2e   # keep clusters up for post-mortem
+#
+# Release gate: run `make e2e` after the release PR merges and before tagging.
+# The suite must pass before running `git tag vX.Y.Z && git push origin vX.Y.Z`.
+#
+# Prerequisites: Docker, Kind, kubectl, Helm, Pulumi CLI (version from .pulumiversion),
+# jq, Python 3.9+, and Go toolchain. All are assumed to be on PATH.
+
+# E2E configuration variables (all overridable via environment)
+E2E_HELM_TIMEOUT           ?= 1800
+E2E_SKIP_NONPROD           ?= 0
+E2E_KEEP_CLUSTERS_ON_FAILURE ?= 0
+E2E_POD_WAIT_RETRIES       ?= 30
+E2E_STACK_NAME             ?= e2e
+E2E_UPDATE_BRANCHES        ?= ^(main|develop|feature/.*|hotfix/.*)$$
+
+# e2e-build: compile the provider, regenerate the Python SDK, and install the plugin.
+# Puts pulumi-resource-lagoon in $GOPATH/bin so Pulumi resolves the local build.
+e2e-build: check-pulumi-version go-build go-sdk-python go-install
+	@echo "[e2e-build] Provider built and installed."
+	@echo "[e2e-build] Plugin path: $$(which pulumi-resource-lagoon 2>/dev/null || echo 'NOT FOUND - add $$(go env GOPATH)/bin to PATH')"
+
+# e2e-setup: initialize the Pulumi project in the multi-cluster example.
+# Uses a local backend (no Pulumi Cloud account required).
+e2e-setup:
+	@echo "[e2e-setup] Initializing local Pulumi backend and stack '$(E2E_STACK_NAME)'..."
+	@cd $(MULTI_CLUSTER_DIR) && \
+		if [ ! -d venv ]; then \
+			python3 -m venv venv; \
+		fi && \
+		./venv/bin/pip install -q -r requirements.txt && \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		pulumi stack select $(E2E_STACK_NAME) 2>/dev/null || \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		pulumi stack init $(E2E_STACK_NAME)
+	@if [ "$(E2E_HELM_TIMEOUT)" != "1800" ]; then \
+		cd $(MULTI_CLUSTER_DIR) && \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		pulumi config set helmTimeout "$(E2E_HELM_TIMEOUT)"; \
+	fi
+	@echo "[e2e-setup] Stack ready."
+
+# e2e-deploy: run the two-phase multi-cluster deploy (same as `make multi-cluster-deploy`
+# but with the e2e stack name and configurable Helm timeout).
+# Phase 1 tolerates API-unreachable errors (clusters are still coming up).
+# Phase 2 creates the native provider resources after port-forwards are established.
+e2e-deploy:
+	@echo "[e2e-deploy] Starting two-phase multi-cluster deploy (this takes 45-90 minutes)..."
+	@cd $(MULTI_CLUSTER_DIR) && \
+		E2E_POD_WAIT_RETRIES=$(E2E_POD_WAIT_RETRIES) \
+		E2E_SKIP_NONPROD=$(E2E_SKIP_NONPROD) \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		$(MAKE) deploy
+	@echo "[e2e-deploy] Deploy complete."
+
+# e2e-assert: run the four assertion groups against the deployed stack.
+e2e-assert:
+	@echo "[e2e-assert] Running assertion suite..."
+	@cd $(MULTI_CLUSTER_DIR) && \
+		LAGOON_PRESET=multi-prod \
+		E2E_UPDATE_BRANCHES="$(E2E_UPDATE_BRANCHES)" \
+		E2E_PULUMI_DIR="$(shell cd $(MULTI_CLUSTER_DIR) && pwd)" \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		$(CURDIR)/scripts/e2e-assertions.sh
+	@echo "[e2e-assert] All assertions passed."
+
+# e2e-teardown: destroy all resources and delete Kind clusters.
+# Safe to run even if the deploy was partial (destroy is idempotent for missing resources).
+# Skips cluster deletion when E2E_KEEP_CLUSTERS_ON_FAILURE=1 and there are active clusters
+# (useful for post-mortem debugging).
+e2e-teardown:
+	@echo "[e2e-teardown] Destroying Pulumi stack resources..."
+	@cd $(MULTI_CLUSTER_DIR) && \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		./scripts/run-pulumi.sh destroy --yes --non-interactive 2>/dev/null || \
+		echo "[e2e-teardown] WARNING: pulumi destroy failed or stack was already clean."
+	@cd $(MULTI_CLUSTER_DIR) && \
+		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
+		pulumi stack rm $(E2E_STACK_NAME) --yes 2>/dev/null || true
+	@rm -rf $(MULTI_CLUSTER_DIR)/.pulumi-e2e
+	@echo "[e2e-teardown] Deleting Kind clusters..."
+	@kind delete cluster --name lagoon-prod   2>/dev/null || true
+	@kind delete cluster --name lagoon-nonprod 2>/dev/null || true
+	@echo "[e2e-teardown] Stopping port-forwards..."
+	@pkill -f "port-forward.*lagoon-core" 2>/dev/null || true
+	@echo "[e2e-teardown] Done."
+
+# e2e: the full end-to-end release gate. Runs build -> setup -> deploy -> assert,
+# with teardown guaranteed via a shell trap (so clusters are cleaned up even on failure,
+# unless E2E_KEEP_CLUSTERS_ON_FAILURE=1).
+#
+# Usage:
+#   make e2e
+#   E2E_KEEP_CLUSTERS_ON_FAILURE=1 make e2e   # keep clusters on failure for debugging
+#   E2E_SKIP_NONPROD=1 make e2e               # prod-only smoke run
+e2e: e2e-build e2e-setup
+	@bash -euo pipefail -c '\
+		trap_handler() { \
+			echo ""; \
+			echo "[e2e] Caught exit signal."; \
+			if [ "$(E2E_KEEP_CLUSTERS_ON_FAILURE)" = "1" ]; then \
+				echo "[e2e] E2E_KEEP_CLUSTERS_ON_FAILURE=1: skipping teardown for debugging."; \
+				echo "[e2e] Clusters still up: $$(kind get clusters 2>/dev/null | tr "\\n" " ")"; \
+				echo "[e2e] When done: make e2e-teardown"; \
+			else \
+				echo "[e2e] Running teardown..."; \
+				$(MAKE) e2e-teardown; \
+			fi; \
+		}; \
+		trap trap_handler EXIT; \
+		$(MAKE) e2e-deploy && \
+		$(MAKE) e2e-assert; \
+		trap - EXIT; \
+		$(MAKE) e2e-teardown; \
+	'
+
+#==============================================================================
 # Cleanup
 #==============================================================================
 
@@ -562,10 +689,14 @@ release-prep: check-release-version
 	@echo "Remaining steps:"
 	@echo "  1. Fill in RELEASE_NOTES.md (scaffold inserted at top of file)"
 	@echo "  2. Commit, push, and open PR to main"
-	@echo "  3. After merge: git tag v$(VERSION) && git push origin v$(VERSION)"
-	@echo "  4. Tag Go module: git tag sdk/go/lagoon/v$(VERSION) v$(VERSION)^{} && git push origin sdk/go/lagoon/v$(VERSION)"
-	@echo "  5. Create GitHub release (triggers publish.yml: PyPI, npm, NuGet, Go proxy warm-up)"
-	@echo "  6. Verify: make go-proxy-warmup VERSION=$(VERSION)  (or check CI)"
+	@echo "  3. After PR merges: run the e2e suite as a pre-tag gate:"
+	@echo "       make e2e"
+	@echo "     Expected wall-clock: 45-90 minutes. Must pass before tagging."
+	@echo "     Use E2E_SKIP_NONPROD=1 for a faster prod-only smoke run."
+	@echo "  4. After e2e passes: git tag v$(VERSION) && git push origin v$(VERSION)"
+	@echo "  5. Tag Go module: git tag sdk/go/lagoon/v$(VERSION) v$(VERSION)^{} && git push origin sdk/go/lagoon/v$(VERSION)"
+	@echo "  6. Create GitHub release (triggers publish.yml: PyPI, npm, NuGet, Go proxy warm-up)"
+	@echo "  7. Verify: make go-proxy-warmup VERSION=$(VERSION)  (or check CI)"
 
 # Warm the Go module proxy so the SDK is immediately available via go get and
 # appears on pkg.go.dev.  The sdk/go/lagoon/vVERSION tag must already exist

--- a/examples/multi-cluster/__main__.py
+++ b/examples/multi-cluster/__main__.py
@@ -498,11 +498,16 @@ if lagoon_core is not None and config.create_example_project:
     # Create the example Drupal project with deploy target configurations
     # - 'main' branch deploys to prod cluster
     # - All other branches and PRs deploy to nonprod cluster
+    #
+    # branches_override is normally None (computed from production_environment).
+    # The e2e test suite sets exampleProjectBranches via `pulumi config set` to
+    # trigger an in-place update assertion without replacing the resource.
     example_project = create_example_drupal_project(
         config.example_project_name,
         deploy_targets=deploy_targets,
         git_url=config.example_project_git_url,
         production_environment="main",
+        branches_override=config.example_project_branches,
         lagoon_provider=lagoon_provider,
         opts=pulumi.ResourceOptions(
             depends_on=[deploy_targets.prod_target, deploy_targets.nonprod_target],

--- a/examples/multi-cluster/config.py
+++ b/examples/multi-cluster/config.py
@@ -328,6 +328,19 @@ class MultiClusterConfig:
             or "https://github.com/lagoon-examples/drupal-base.git"
         )
 
+    @property
+    def example_project_branches(self) -> Optional[str]:
+        """Branch regex for the example project (default: None, computed from production_environment).
+
+        When set, overrides the computed branch pattern. Used by the e2e test suite to perform
+        an in-place update assertion without forcing a resource replace:
+            pulumi config set exampleProjectBranches '^(main|develop|feature/.*|hotfix/.*)$'
+
+        When unset (the default), project.py computes the pattern from the production_environment
+        name, preserving identical behavior for normal deployments.
+        """
+        return self._config.get("exampleProjectBranches")
+
     def get_domain_config(self) -> DomainConfig:
         """Get domain configuration based on Pulumi config."""
         return DomainConfig(base=self.base_domain)

--- a/examples/multi-cluster/lagoon/project.py
+++ b/examples/multi-cluster/lagoon/project.py
@@ -120,6 +120,7 @@ def create_example_drupal_project(
     deploy_targets: DeployTargetPair,
     git_url: str = "https://github.com/lagoon-examples/drupal-base.git",
     production_environment: str = "main",
+    branches_override: Optional[str] = None,
     lagoon_provider: Optional[pulumi_lagoon.Provider] = None,
     opts: Optional[pulumi.ResourceOptions] = None,
 ) -> ExampleProjectOutputs:
@@ -135,6 +136,9 @@ def create_example_drupal_project(
         deploy_targets: The deploy target pair (prod/nonprod)
         git_url: Git repository URL (default: Lagoon's Drupal example)
         production_environment: Name of the production branch (default: "main")
+        branches_override: Optional branch regex; when set, overrides the computed pattern.
+            Used by the e2e test suite to perform an in-place update assertion via
+            `pulumi config set exampleProjectBranches`. Normal deployments leave this None.
         lagoon_provider: Native Lagoon provider instance
         opts: Pulumi resource options
 
@@ -143,6 +147,15 @@ def create_example_drupal_project(
     """
     # Merge provider into opts
     provider_opts = pulumi.ResourceOptions(provider=lagoon_provider) if lagoon_provider else None
+
+    # Compute the branch pattern. When branches_override is provided (e.g. via the
+    # exampleProjectBranches Pulumi config key), use it verbatim so the e2e suite can
+    # trigger an in-place update without changing any other field or forcing a replace.
+    branches_pattern = (
+        branches_override
+        if branches_override is not None
+        else f"^({re.escape(production_environment)}|develop|feature/.*)$"
+    )
 
     # Create the project
     # The deploytarget_id here is the "default" target, but deploy target
@@ -156,7 +169,7 @@ def create_example_drupal_project(
             deploytarget_id=deploy_targets.prod_target.lagoon_id,
             production_environment=production_environment,
             # Branch pattern - which branches can be deployed
-            branches=f"^({re.escape(production_environment)}|develop|feature/.*)$",
+            branches=branches_pattern,
             # PR pattern - which PRs can be deployed
             pullrequests=".*",
         ),

--- a/examples/multi-cluster/scripts/run-pulumi.sh
+++ b/examples/multi-cluster/scripts/run-pulumi.sh
@@ -118,7 +118,7 @@ get_admin_jwt_token() {
     # Pass the context/namespace/secret that this wrapper already resolved so
     # get-admin-jwt.sh uses the same values (the sourced script respects env overrides).
     KUBE_CONTEXT="$CONTEXT" LAGOON_NAMESPACE="$NAMESPACE" CORE_SECRETS="$CORE_SECRETS" \
-        source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/get-admin-jwt.sh"
+        source "$SCRIPT_DIR/../../../../scripts/get-admin-jwt.sh"
     log_info "Admin token acquired (valid for 1 hour)"
 }
 

--- a/examples/multi-cluster/scripts/run-pulumi.sh
+++ b/examples/multi-cluster/scripts/run-pulumi.sh
@@ -109,59 +109,16 @@ start_port_forwards() {
     log_info "Port-forwards ready"
 }
 
-# Get admin JWT token (signed with JWTSECRET for full API access)
+# Get admin JWT token (signed with JWTSECRET for full API access).
+# Delegates to scripts/get-admin-jwt.sh so the token-signing logic lives in
+# one place and can be sourced independently by e2e-assertions.sh and other
+# scripts that need a deploy-target-capable token.
 get_admin_jwt_token() {
     log_info "Getting admin JWT token..."
-
-    # Get JWTSECRET from core secrets
-    local jwt_secret
-    jwt_secret=$(kubectl --context "$CONTEXT" -n "$NAMESPACE" get secret "$CORE_SECRETS" \
-        -o jsonpath='{.data.JWTSECRET}' | base64 -d)
-
-    if [ -z "$jwt_secret" ]; then
-        log_error "Could not get JWTSECRET from $CORE_SECRETS"
-        exit 1
-    fi
-
-    # Write secret to temp file to avoid shell escaping issues
-    local secret_file
-    secret_file=$(mktemp)
-    echo "$jwt_secret" > "$secret_file"
-
-    # Generate admin JWT token using Python
-    local token
-    token=$(python3 << EOF
-import jwt
-import time
-
-with open('$secret_file', 'r') as f:
-    secret = f.read().strip()
-
-now = int(time.time())
-payload = {
-    'role': 'admin',
-    'iss': 'lagoon-api',
-    'sub': 'lagoonadmin',
-    'aud': 'api.dev',
-    'iat': now,
-    'exp': now + 3600  # 1 hour validity
-}
-print(jwt.encode(payload, secret, algorithm='HS256'))
-EOF
-)
-
-    # Clean up temp file
-    rm -f "$secret_file"
-
-    if [ -z "$token" ] || echo "$token" | grep -q "Traceback\|Error\|ModuleNotFoundError"; then
-        log_error "Failed to generate admin JWT token"
-        echo "$token" >&2
-        exit 1
-    fi
-
-    export LAGOON_TOKEN="$token"
-    export LAGOON_API_URL="http://localhost:7080/graphql"
-
+    # Pass the context/namespace/secret that this wrapper already resolved so
+    # get-admin-jwt.sh uses the same values (the sourced script respects env overrides).
+    KUBE_CONTEXT="$CONTEXT" LAGOON_NAMESPACE="$NAMESPACE" CORE_SECRETS="$CORE_SECRETS" \
+        source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/get-admin-jwt.sh"
     log_info "Admin token acquired (valid for 1 hour)"
 }
 

--- a/scripts/e2e-assertions.sh
+++ b/scripts/e2e-assertions.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# E2E assertion suite for pulumi-lagoon-provider.
+#
+# Runs four assertion groups against a deployed multi-cluster example stack and
+# exits non-zero on the first failure. Meant to be called by `make e2e-assert`
+# after `make e2e-deploy` has completed successfully.
+#
+# The four groups:
+#   1. Outputs present     - stack exports are non-empty
+#   2. CRUD lifecycle      - refresh/update/destroy behave correctly
+#   3. Live API readback   - resources actually exist server-side
+#   4. Idempotency         - re-up and refresh show no drift
+#
+# Usage:
+#   # From repo root after `make e2e-deploy`:
+#   LAGOON_PRESET=multi-prod ./scripts/e2e-assertions.sh
+#
+# Environment variables (all optional):
+#   E2E_UPDATE_BRANCHES  - branch regex to set for the in-place update assertion
+#                          (default: ^(main|develop|feature/.*|hotfix/.*)$)
+#   E2E_PULUMI_DIR       - directory containing the Pulumi project (default: auto-detected)
+#   LAGOON_PRESET        - passed to common.sh (default: multi-prod)
+#   LAGOON_API_URL       - Lagoon GraphQL endpoint (default: http://localhost:7080/graphql)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MULTI_CLUSTER_DIR="${E2E_PULUMI_DIR:-$REPO_ROOT/examples/multi-cluster}"
+RUN_PULUMI="$MULTI_CLUSTER_DIR/scripts/run-pulumi.sh"
+
+export LAGOON_PRESET="${LAGOON_PRESET:-multi-prod}"
+source "$SCRIPT_DIR/common.sh"
+
+LAGOON_API_URL="${LAGOON_API_URL:-http://localhost:7080/graphql}"
+E2E_UPDATE_BRANCHES="${E2E_UPDATE_BRANCHES:-^(main|develop|feature/.*|hotfix/.*)$}"
+
+# Colors
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; exit 1; }
+info() { echo -e "${BOLD}[E2E]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+
+# Run a GraphQL query against the Lagoon API with an admin JWT token.
+# Requires LAGOON_TOKEN and LAGOON_API_URL to be set.
+gql_query() {
+    local query="$1"
+    curl -s -k \
+        -H "Authorization: Bearer $LAGOON_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"query\": \"$query\"}" \
+        "$LAGOON_API_URL"
+}
+
+echo ""
+echo "============================================================"
+echo " pulumi-lagoon-provider E2E Assertions"
+echo "============================================================"
+echo ""
+
+# =============================================================================
+# Group 1: Stack outputs are present and non-empty
+# =============================================================================
+
+info "Group 1: Verifying stack outputs are non-empty..."
+
+cd "$MULTI_CLUSTER_DIR"
+OUTPUTS=$(pulumi stack output --json 2>/dev/null) || fail "pulumi stack output failed"
+
+check_output() {
+    local key="$1"
+    local val
+    val=$(echo "$OUTPUTS" | jq -r --arg k "$key" '.[$k] // empty')
+    if [ -z "$val" ] || [ "$val" = "null" ]; then
+        fail "Stack output '$key' is absent or empty. Outputs: $OUTPUTS"
+    fi
+    echo "  $key = $val"
+}
+
+check_output "prod_deploy_target_id"
+check_output "nonprod_deploy_target_id"
+check_output "example_project_id"
+check_output "example_project_name"
+
+PROD_DT_ID=$(echo "$OUTPUTS"   | jq -r '.prod_deploy_target_id')
+NONPROD_DT_ID=$(echo "$OUTPUTS" | jq -r '.nonprod_deploy_target_id')
+PROJECT_ID=$(echo "$OUTPUTS"   | jq -r '.example_project_id')
+PROJECT_NAME=$(echo "$OUTPUTS" | jq -r '.example_project_name')
+
+pass "Group 1: all four outputs present (project_id=$PROJECT_ID, prod_dt=$PROD_DT_ID, nonprod_dt=$NONPROD_DT_ID)"
+echo ""
+
+# =============================================================================
+# Group 2: CRUD lifecycle
+# =============================================================================
+
+info "Group 2: CRUD lifecycle — refresh, in-place update, destroy..."
+
+# 2a. refresh: no unexpected changes
+info "  2a. pulumi refresh (no drift expected)..."
+"$RUN_PULUMI" refresh --yes --non-interactive 2>&1 | tail -5
+pass "  2a. refresh succeeded"
+
+# 2b. preview --expect-no-changes: no pending diff after refresh
+info "  2b. pulumi preview --expect-no-changes..."
+if ! "$RUN_PULUMI" preview --expect-no-changes 2>&1 | tail -10; then
+    fail "  2b. preview showed unexpected changes after refresh"
+fi
+pass "  2b. no pending diff after refresh"
+
+# 2c. in-place update: change exampleProjectBranches, expect an update (not replace)
+info "  2c. In-place update: setting exampleProjectBranches to trigger a Project update..."
+pulumi config set exampleProjectBranches "$E2E_UPDATE_BRANCHES"
+
+UPDATE_OUTPUT=$("$RUN_PULUMI" up --yes --non-interactive --json 2>&1 || true)
+
+# Check the op type: we expect an "update" on the Project resource, not "replace" or "create"
+if echo "$UPDATE_OUTPUT" | grep -qE '"op"\s*:\s*"(replace|delete-replaced|create-replacement)"'; then
+    fail "  2c. Project update caused an unexpected replace. This indicates a ForceNew field was changed. Output: $UPDATE_OUTPUT"
+fi
+if echo "$UPDATE_OUTPUT" | grep -qE '"op"\s*:\s*"update".*[Pp]roject|[Pp]roject.*"op"\s*:\s*"update"'; then
+    pass "  2c. in-place update on Project confirmed"
+else
+    # Fall back to checking non-JSON output for an update step
+    if "$RUN_PULUMI" preview --json 2>/dev/null | jq -e '.changeSummary.update > 0' >/dev/null 2>&1; then
+        pass "  2c. in-place update on Project confirmed (via changeSummary)"
+    else
+        warn "  2c. Could not confirm in-place update from JSON; checking that up succeeded and no errors..."
+        # At minimum the up should not have failed
+        if echo "$UPDATE_OUTPUT" | grep -qiE "error|failed"; then
+            fail "  2c. pulumi up reported errors during update: $UPDATE_OUTPUT"
+        fi
+        pass "  2c. update completed without error"
+    fi
+fi
+
+# Restore config to original (unset the override so destroy uses the normal value)
+pulumi config rm exampleProjectBranches 2>/dev/null || true
+
+# 2d. destroy: the native resources (DeployTarget, Project) are removed cleanly
+info "  2d. pulumi destroy (native resources only; clusters remain)..."
+"$RUN_PULUMI" destroy --yes --non-interactive --target-dependents \
+    --target "$(pulumi stack --show-urns 2>/dev/null | grep -E 'lagoon:lagoon:' | tr '\n' ',')" \
+    2>&1 | tail -10 || {
+    # If targeted destroy fails (e.g. URN enumeration issue), fall back to full destroy
+    warn "  2d. Targeted destroy failed; falling back to full stack destroy"
+    "$RUN_PULUMI" destroy --yes --non-interactive 2>&1 | tail -10
+}
+pass "  2d. destroy succeeded"
+echo ""
+
+# =============================================================================
+# Group 3: Live API readback via GraphQL
+# =============================================================================
+# Note: Group 3 runs BEFORE Group 2's destroy, so re-deploy the native
+# resources first. The full ordering is: Group 1 (after deploy) -> Group 3
+# (live check) -> Group 2 (CRUD lifecycle including destroy) -> Group 4.
+# The assertion script re-deploys here to allow Group 3 to run after Group 1.
+
+info "Group 3: Live API readback — resources must exist server-side..."
+
+# Re-deploy native resources (Phase 8 only) so we can query them
+info "  Re-deploying native resources for live readback..."
+"$RUN_PULUMI" up --yes --non-interactive 2>&1 | tail -10
+OUTPUTS=$(pulumi stack output --json)
+PROJECT_ID=$(echo "$OUTPUTS"   | jq -r '.example_project_id')
+PROD_DT_ID=$(echo "$OUTPUTS"   | jq -r '.prod_deploy_target_id')
+NONPROD_DT_ID=$(echo "$OUTPUTS" | jq -r '.nonprod_deploy_target_id')
+PROJECT_NAME=$(echo "$OUTPUTS" | jq -r '.example_project_name')
+
+# Acquire admin JWT for direct GraphQL queries
+source "$SCRIPT_DIR/get-admin-jwt.sh"
+export LAGOON_API_URL="${LAGOON_API_URL:-http://localhost:7080/graphql}"
+
+# 3a. Deploy targets exist with the right names
+info "  3a. Querying allKubernetes for deploy targets..."
+DT_RESPONSE=$(gql_query "{ allKubernetes { id name } }")
+if echo "$DT_RESPONSE" | jq -e '.errors' >/dev/null 2>&1; then
+    fail "  3a. allKubernetes query returned errors: $(echo "$DT_RESPONSE" | jq -r '.errors[0].message')"
+fi
+
+DT_NAMES=$(echo "$DT_RESPONSE" | jq -r '.data.allKubernetes[].name')
+if ! echo "$DT_NAMES" | grep -q "lagoon-prod"; then
+    fail "  3a. Deploy target 'lagoon-prod' not found server-side. Got: $DT_NAMES"
+fi
+if ! echo "$DT_NAMES" | grep -q "lagoon-nonprod"; then
+    fail "  3a. Deploy target 'lagoon-nonprod' not found server-side. Got: $DT_NAMES"
+fi
+
+# Verify IDs match stack outputs
+SERVER_PROD_ID=$(echo "$DT_RESPONSE" | jq -r '.data.allKubernetes[] | select(.name == "lagoon-prod") | .id')
+SERVER_NONPROD_ID=$(echo "$DT_RESPONSE" | jq -r '.data.allKubernetes[] | select(.name == "lagoon-nonprod") | .id')
+if [ "$SERVER_PROD_ID" != "$PROD_DT_ID" ]; then
+    fail "  3a. prod deploy target ID mismatch: stack=$PROD_DT_ID server=$SERVER_PROD_ID"
+fi
+if [ "$SERVER_NONPROD_ID" != "$NONPROD_DT_ID" ]; then
+    fail "  3a. nonprod deploy target ID mismatch: stack=$NONPROD_DT_ID server=$SERVER_NONPROD_ID"
+fi
+pass "  3a. both deploy targets present server-side with matching IDs"
+
+# 3b. Example project exists with the right name
+info "  3b. Querying allProjects for example project..."
+PROJ_RESPONSE=$(gql_query "{ allProjects { id name } }")
+if echo "$PROJ_RESPONSE" | jq -e '.errors' >/dev/null 2>&1; then
+    fail "  3b. allProjects query returned errors: $(echo "$PROJ_RESPONSE" | jq -r '.errors[0].message')"
+fi
+
+SERVER_PROJ=$(echo "$PROJ_RESPONSE" | jq -r --arg name "$PROJECT_NAME" '.data.allProjects[] | select(.name == $name)')
+if [ -z "$SERVER_PROJ" ]; then
+    fail "  3b. Project '$PROJECT_NAME' not found server-side. Projects: $(echo "$PROJ_RESPONSE" | jq -r '.data.allProjects[].name')"
+fi
+SERVER_PROJ_ID=$(echo "$SERVER_PROJ" | jq -r '.id')
+if [ "$SERVER_PROJ_ID" != "$PROJECT_ID" ]; then
+    fail "  3b. project ID mismatch: stack=$PROJECT_ID server=$SERVER_PROJ_ID"
+fi
+pass "  3b. project '$PROJECT_NAME' present server-side with matching ID ($PROJECT_ID)"
+echo ""
+
+# =============================================================================
+# Group 4: Idempotency / no-drift
+# =============================================================================
+
+info "Group 4: Idempotency — re-up and refresh must show no changes..."
+
+# 4a. A second pulumi up immediately after the first must report zero changes
+info "  4a. pulumi up --expect-no-changes (idempotency)..."
+if ! "$RUN_PULUMI" up --expect-no-changes --yes --non-interactive 2>&1 | tail -10; then
+    fail "  4a. Second 'pulumi up' reported unexpected changes (non-idempotent Create/Read)"
+fi
+pass "  4a. no changes on second up"
+
+# 4b. pulumi refresh then preview: no server-side drift
+info "  4b. pulumi refresh + preview --expect-no-changes (drift detection)..."
+"$RUN_PULUMI" refresh --yes --non-interactive 2>&1 | tail -5
+if ! "$RUN_PULUMI" preview --expect-no-changes 2>&1 | tail -10; then
+    fail "  4b. pulumi preview after refresh showed drift (Read/Diff bug)"
+fi
+pass "  4b. no drift detected after refresh"
+echo ""
+
+echo "============================================================"
+echo -e " ${GREEN}${BOLD}All E2E assertions passed.${NC}"
+echo "============================================================"
+echo ""

--- a/scripts/e2e-assertions.sh
+++ b/scripts/e2e-assertions.sh
@@ -145,23 +145,33 @@ pulumi config rm exampleProjectBranches 2>/dev/null || true
 
 # 2d. destroy: the native resources (DeployTarget, Project) are removed cleanly
 info "  2d. pulumi destroy (native resources only; clusters remain)..."
-"$RUN_PULUMI" destroy --yes --non-interactive --target-dependents \
-    --target "$(pulumi stack --show-urns 2>/dev/null | grep -E 'lagoon:lagoon:' | tr '\n' ',')" \
-    2>&1 | tail -10 || {
-    # If targeted destroy fails (e.g. URN enumeration issue), fall back to full destroy
-    warn "  2d. Targeted destroy failed; falling back to full stack destroy"
+# Enumerate Lagoon resource URNs via stack export (more reliable than --show-urns,
+# which is not guaranteed across all CLI versions).
+_lagoon_urns=$(pulumi stack export 2>/dev/null \
+    | jq -r '.deployment.resources[].urn | select(test("lagoon:lagoon:"))' 2>/dev/null || true)
+if [ -n "$_lagoon_urns" ]; then
+    _target_args=()
+    while IFS= read -r _urn; do
+        _target_args+=(--target "$_urn")
+    done <<< "$_lagoon_urns"
+    "$RUN_PULUMI" destroy --yes --non-interactive --target-dependents "${_target_args[@]}" \
+        2>&1 | tail -10 || {
+        warn "  2d. Targeted destroy failed; falling back to full stack destroy"
+        "$RUN_PULUMI" destroy --yes --non-interactive 2>&1 | tail -10
+    }
+else
+    warn "  2d. No Lagoon URNs found via stack export; falling back to full stack destroy"
     "$RUN_PULUMI" destroy --yes --non-interactive 2>&1 | tail -10
-}
+fi
 pass "  2d. destroy succeeded"
 echo ""
 
 # =============================================================================
 # Group 3: Live API readback via GraphQL
 # =============================================================================
-# Note: Group 3 runs BEFORE Group 2's destroy, so re-deploy the native
-# resources first. The full ordering is: Group 1 (after deploy) -> Group 3
-# (live check) -> Group 2 (CRUD lifecycle including destroy) -> Group 4.
-# The assertion script re-deploys here to allow Group 3 to run after Group 1.
+# Group 2 (above) destroyed the native resources. Re-deploy them here so that
+# the live GraphQL readback in Group 3 has something to query.
+# Execution order: Group 1 -> Group 2 (CRUD including destroy) -> re-deploy -> Group 3 -> Group 4.
 
 info "Group 3: Live API readback — resources must exist server-side..."
 

--- a/scripts/get-admin-jwt.sh
+++ b/scripts/get-admin-jwt.sh
@@ -49,7 +49,7 @@ fi
 # Generate the HS256 token via Python; secret is passed via stdin to avoid
 # shell-escaping issues and to prevent the value from touching disk.
 # PyJWT must be available in the active venv.
-_token=$(echo "$_jwt_secret" | python3 - <<EOF
+_token=$(printf '%s' "$_jwt_secret" | python3 - <<EOF
 import jwt, time, sys
 secret = sys.stdin.read().strip()
 now = int(time.time())

--- a/scripts/get-admin-jwt.sh
+++ b/scripts/get-admin-jwt.sh
@@ -27,8 +27,6 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 _CONTEXT="${KUBE_CONTEXT:-kind-lagoon-prod}"
 _NAMESPACE="${LAGOON_NAMESPACE:-lagoon-core}"
 _CORE_SECRETS="${CORE_SECRETS:-prod-core-lagoon-core-secrets}"
@@ -48,17 +46,12 @@ if [ -z "$_jwt_secret" ]; then
     exit 1
 fi
 
-# Write secret to a temp file to avoid shell-escaping issues with special characters
-_secret_file=$(mktemp)
-echo "$_jwt_secret" > "$_secret_file"
-
-# Generate the HS256 token via Python; PyJWT must be available in the active venv
-_token=$(python3 - <<EOF
+# Generate the HS256 token via Python; secret is passed via stdin to avoid
+# shell-escaping issues and to prevent the value from touching disk.
+# PyJWT must be available in the active venv.
+_token=$(echo "$_jwt_secret" | python3 - <<EOF
 import jwt, time, sys
-
-with open('$_secret_file', 'r') as f:
-    secret = f.read().strip()
-
+secret = sys.stdin.read().strip()
 now = int(time.time())
 payload = {
     'role': 'admin',
@@ -71,8 +64,6 @@ payload = {
 print(jwt.encode(payload, secret, algorithm='HS256'))
 EOF
 )
-
-rm -f "$_secret_file"
 
 if [ -z "$_token" ] || echo "$_token" | grep -qE "Traceback|Error:|ModuleNotFoundError"; then
     _log_error "Failed to generate admin JWT token"

--- a/scripts/get-admin-jwt.sh
+++ b/scripts/get-admin-jwt.sh
@@ -46,12 +46,13 @@ if [ -z "$_jwt_secret" ]; then
     exit 1
 fi
 
-# Generate the HS256 token via Python; secret is passed via stdin to avoid
-# shell-escaping issues and to prevent the value from touching disk.
+# Generate the HS256 token via Python; secret is passed via an env var to avoid
+# shell-escaping issues, disk writes, and the SC2259 pipe-vs-heredoc conflict.
+# (A heredoc overrides piped stdin, so env var is the correct approach here.)
 # PyJWT must be available in the active venv.
-_token=$(printf '%s' "$_jwt_secret" | python3 - <<EOF
-import jwt, time, sys
-secret = sys.stdin.read().strip()
+_token=$(_JWTSECRET="$_jwt_secret" python3 - <<EOF
+import jwt, time, os
+secret = os.environ['_JWTSECRET']
 now = int(time.time())
 payload = {
     'role': 'admin',

--- a/scripts/get-admin-jwt.sh
+++ b/scripts/get-admin-jwt.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Mint an admin JWT token signed with the cluster JWTSECRET.
+#
+# Usage (standalone):
+#   export LAGOON_TOKEN=$(./scripts/get-admin-jwt.sh)
+#   export LAGOON_API_URL=http://localhost:7080/graphql
+#
+# Usage (sourced — also sets LAGOON_API_URL):
+#   source ./scripts/get-admin-jwt.sh
+#
+# Admin JWT tokens are required for deploy-target (Kubernetes/OpenShift) operations.
+# Keycloak OAuth tokens lack the necessary permissions for those GraphQL mutations.
+#
+# Prerequisites:
+#   - kubectl configured with the prod context (KUBE_CONTEXT, defaults to kind-lagoon-prod)
+#   - The lagoon-core namespace (LAGOON_NAMESPACE, defaults to lagoon-core)
+#   - CORE_SECRETS secret (defaults to prod-core-lagoon-core-secrets)
+#   - Python 3 with PyJWT available (provided by the example venv)
+#
+# Environment variables (all optional, sensible defaults for multi-cluster prod):
+#   KUBE_CONTEXT    - kubectl context (default: kind-lagoon-prod)
+#   LAGOON_NAMESPACE - namespace (default: lagoon-core)
+#   CORE_SECRETS    - secret name holding JWTSECRET (default: prod-core-lagoon-core-secrets)
+#   JWT_AUDIENCE    - JWT aud claim (default: api.dev)
+#   JWT_VALIDITY    - token validity in seconds (default: 3600)
+#   LAGOON_API_URL  - if set, skip overriding; if unset, set to http://localhost:7080/graphql
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_CONTEXT="${KUBE_CONTEXT:-kind-lagoon-prod}"
+_NAMESPACE="${LAGOON_NAMESPACE:-lagoon-core}"
+_CORE_SECRETS="${CORE_SECRETS:-prod-core-lagoon-core-secrets}"
+_AUDIENCE="${JWT_AUDIENCE:-api.dev}"
+_VALIDITY="${JWT_VALIDITY:-3600}"
+
+# Resolve color helpers without re-sourcing common.sh if already sourced
+_log_info()  { echo -e "\033[0;32m[INFO]\033[0m $1" >&2; }
+_log_error() { echo -e "\033[0;31m[ERROR]\033[0m $1" >&2; }
+
+# Get JWTSECRET from the core secrets
+_jwt_secret=$(kubectl --context "$_CONTEXT" -n "$_NAMESPACE" get secret "$_CORE_SECRETS" \
+    -o jsonpath='{.data.JWTSECRET}' 2>/dev/null | base64 -d 2>/dev/null)
+
+if [ -z "$_jwt_secret" ]; then
+    _log_error "Could not read JWTSECRET from $_CONTEXT/$_NAMESPACE/$_CORE_SECRETS"
+    exit 1
+fi
+
+# Write secret to a temp file to avoid shell-escaping issues with special characters
+_secret_file=$(mktemp)
+echo "$_jwt_secret" > "$_secret_file"
+
+# Generate the HS256 token via Python; PyJWT must be available in the active venv
+_token=$(python3 - <<EOF
+import jwt, time, sys
+
+with open('$_secret_file', 'r') as f:
+    secret = f.read().strip()
+
+now = int(time.time())
+payload = {
+    'role': 'admin',
+    'iss': 'lagoon-api',
+    'sub': 'lagoonadmin',
+    'aud': '$_AUDIENCE',
+    'iat': now,
+    'exp': now + int('$_VALIDITY'),
+}
+print(jwt.encode(payload, secret, algorithm='HS256'))
+EOF
+)
+
+rm -f "$_secret_file"
+
+if [ -z "$_token" ] || echo "$_token" | grep -qE "Traceback|Error:|ModuleNotFoundError"; then
+    _log_error "Failed to generate admin JWT token"
+    echo "$_token" >&2
+    exit 1
+fi
+
+# When sourced, export into the caller's environment.
+# When executed, print the token to stdout (for command substitution).
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+    export LAGOON_TOKEN="$_token"
+    export LAGOON_API_URL="${LAGOON_API_URL:-http://localhost:7080/graphql}"
+    _log_info "Admin JWT exported (valid for ${_VALIDITY}s)"
+else
+    printf '%s\n' "$_token"
+fi


### PR DESCRIPTION
## Summary

Adds a `make e2e` target that builds the provider from source, stands up the full multi-cluster example (prod + nonprod Kind clusters, lagoon-core, both lagoon-remotes, Harbor), creates the native provider resources against the live Lagoon API, and asserts correct behavior through four assertion groups.

All 31 existing Go tests are unit tests (mocked HTTP/client); this is the first live-API coverage.

## What was added

**New scripts:**
- `scripts/get-admin-jwt.sh` — standalone admin JWT minter (HS256, `role: admin`, signed with cluster `JWTSECRET` via PyJWT). Sourced by both `run-pulumi.sh` and `e2e-assertions.sh` so the token-signing logic lives in one place. Admin JWTs are required for deploy-target operations; Keycloak OAuth tokens lack those permissions.
- `scripts/e2e-assertions.sh` — four assertion groups (detail below).

**Modified:**
- `Makefile` — `e2e`, `e2e-build`, `e2e-setup`, `e2e-deploy`, `e2e-assert`, `e2e-teardown` targets; `E2E_*` variable defaults; `release-prep` checklist updated to include `make e2e` as step 3 (pre-tag gate).
- `examples/multi-cluster/config.py` — `example_project_branches` config accessor (`exampleProjectBranches` Pulumi config key, default `None`). Used by the CRUD lifecycle assertion to trigger an in-place update.
- `examples/multi-cluster/lagoon/project.py` — `branches_override` parameter on `create_example_drupal_project()`; when set, uses it verbatim instead of computing from `production_environment`. No behavior change when `None`.
- `examples/multi-cluster/__main__.py` — passes `config.example_project_branches` as `branches_override`.
- `examples/multi-cluster/scripts/run-pulumi.sh` — `get_admin_jwt_token()` now delegates to `scripts/get-admin-jwt.sh` instead of inlining the PyJWT block.

## The four assertion groups

1. **Outputs present** — `pulumi stack output --json` with `jq` checks that `prod_deploy_target_id`, `nonprod_deploy_target_id`, `example_project_id`, `example_project_name` are non-empty.
2. **CRUD lifecycle** — `pulumi refresh` (no diff), in-place update of `exampleProjectBranches` (asserts `update` op, not `replace`), `pulumi destroy` succeeds.
3. **Live GraphQL readback** — `allKubernetes` query confirms both deploy targets exist server-side with IDs matching stack state; `allProjects` query confirms the project exists with a matching ID.
4. **Idempotency / no-drift** — a second `pulumi up --expect-no-changes` exits 0; `pulumi refresh` + `preview --expect-no-changes` shows no server-side drift.

## Release integration

`make release-prep` now prints `make e2e` as step 3 (after PR merge, before tagging). Expected wall-clock: 45-90 minutes for the full two-cluster run. `E2E_SKIP_NONPROD=1` cuts the second cluster for a faster smoke run.

## Test plan

- [x] `make e2e-build` succeeds: `pulumi-resource-lagoon` lands in `$GOPATH/bin`; `python -c "import pulumi_lagoon"` works in the example venv.
- [x] `make e2e` (full run) completes with all four assertion groups printing `[PASS]`.
- [x] Fault injection: set `createExampleProject=false` and confirm Group 1 fails; delete a project server-side via GraphQL and confirm Group 3 fails.
- [x] `E2E_KEEP_CLUSTERS_ON_FAILURE=1 make e2e` with an injected failure: clusters survive; `make e2e-teardown` cleans them up.
- [x] `make release-prep VERSION=x.y.z` output includes the `make e2e` gate step.