### PR TITLE
chore: ignore .serena/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ dmypy.json
 # Claude Code
 .claude/
 memory-bank/
+.serena/
 
 # Legacy Python dynamic provider artifact (pre-v0.2.0); real SDK is in sdk/python/.
 # Empty if present locally; listed here to prevent accidental commits and to avoid


### PR DESCRIPTION
## Summary

Adds `.serena/` to `.gitignore`. The Serena MCP tool (used alongside Claude Code) creates a local `.serena/` cache directory in the repo root, which was showing up as untracked. This adds it to the existing Claude Code section of `.gitignore` so it isn't accidentally committed.

## Changes

- `.gitignore`: one-line addition (`.serena/`) under the existing `# Claude Code` section.

## Test plan

- [ ] `git status` no longer reports `.serena/` as untracked
- [ ] No other files affected by the ignore rule