### PR TITLE
chore(renovate): add automerge for minor/patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>tag1consulting/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `packageRules` with `automerge: true` and `automergeType: "pr"` for minor and patch updates.
- Branch protection on `main` now requires the `review` status check (ai-pr-review), so PRs auto-merge only after ai-pr-review approves them.

This mirrors the setup on `ai-pr-review` and `claude-comprehensive-review`.

## Test plan

- [ ] Verify next Renovate PR auto-merges after ai-pr-review approves it