### PR TITLE
fix(e2e): resolve local e2e harness bugs blocking the release gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,9 @@ E2E_KEEP_CLUSTERS_ON_FAILURE ?= 0
 E2E_POD_WAIT_RETRIES       ?= 30
 E2E_STACK_NAME             ?= e2e
 E2E_UPDATE_BRANCHES        ?= ^(main|develop|feature/.*|hotfix/.*)$$
+# Empty passphrase disables encryption for this throwaway local-backend stack;
+# e2e state holds no real secrets and is destroyed by e2e-teardown every run.
+export PULUMI_CONFIG_PASSPHRASE ?=
 
 # e2e-build: compile the provider, regenerate the Python SDK, and install the plugin.
 # Puts pulumi-resource-lagoon in $GOPATH/bin so Pulumi resolves the local build.
@@ -357,6 +360,7 @@ e2e-build: check-pulumi-version go-build go-sdk-python go-install
 # Uses a local backend (no Pulumi Cloud account required).
 e2e-setup:
 	@echo "[e2e-setup] Initializing local Pulumi backend and stack '$(E2E_STACK_NAME)'..."
+	@mkdir -p $(MULTI_CLUSTER_DIR)/.pulumi-e2e
 	@cd $(MULTI_CLUSTER_DIR) && \
 		if [ ! -d venv ]; then \
 			python3 -m venv venv; \
@@ -383,7 +387,7 @@ e2e-deploy:
 		E2E_POD_WAIT_RETRIES=$(E2E_POD_WAIT_RETRIES) \
 		E2E_SKIP_NONPROD=$(E2E_SKIP_NONPROD) \
 		PULUMI_BACKEND_URL="file://$(shell cd $(MULTI_CLUSTER_DIR) && pwd)/.pulumi-e2e" \
-		$(MAKE) deploy
+		$(MAKE) deploy STACK_NAME=$(E2E_STACK_NAME)
 	@echo "[e2e-deploy] Deploy complete."
 
 # e2e-assert: run the four assertion groups against the deployed stack.
@@ -500,6 +504,10 @@ clean-all: clean
 PROVIDER_VERSION ?= 0.5.2
 PROVIDER_BIN     := provider/bin/pulumi-resource-lagoon
 GO_BIN           ?= $(if $(GOPATH),$(GOPATH)/bin,$(HOME)/go/bin)
+# e2e-build installs the locally-built provider plugin into GO_BIN so Pulumi's
+# ambient-plugin discovery finds it on PATH instead of downloading a GitHub
+# release (which 404s for an unreleased version like the one being e2e-tested).
+export PATH := $(GO_BIN):$(PATH)
 
 go-build:
 	cd provider && mkdir -p bin && CGO_ENABLED=0 go build -ldflags "-X main.Version=$(PROVIDER_VERSION)" \

--- a/examples/multi-cluster/Makefile
+++ b/examples/multi-cluster/Makefile
@@ -19,6 +19,10 @@
         deploy verify wait-for-pods test-api test-ui show-access-info \
         test test-unit test-config test-cors test-operational
 
+# Stack name for `setup`/`deploy`; overridden by e2e (see e2e-deploy in root Makefile)
+# so it reuses the stack e2e-setup already created instead of selecting/creating 'dev'.
+STACK_NAME ?= dev
+
 # Default target
 help:
 	@echo "Multi-cluster Lagoon Example"
@@ -74,7 +78,7 @@ setup:
 	@./venv/bin/pip install --upgrade pip -q
 	@./venv/bin/pip install -r requirements.txt -q
 	@echo "Ensuring Pulumi stack exists..."
-	@pulumi stack select dev 2>/dev/null || pulumi stack init dev
+	@pulumi stack select $(STACK_NAME) 2>/dev/null || pulumi stack init $(STACK_NAME)
 	@echo "Setup complete."
 
 # Check cluster health

--- a/examples/multi-cluster/scripts/run-pulumi.sh
+++ b/examples/multi-cluster/scripts/run-pulumi.sh
@@ -118,7 +118,7 @@ get_admin_jwt_token() {
     # Pass the context/namespace/secret that this wrapper already resolved so
     # get-admin-jwt.sh uses the same values (the sourced script respects env overrides).
     KUBE_CONTEXT="$CONTEXT" LAGOON_NAMESPACE="$NAMESPACE" CORE_SECRETS="$CORE_SECRETS" \
-        source "$SCRIPT_DIR/../../../../scripts/get-admin-jwt.sh"
+        source "$SCRIPT_DIR/../../../scripts/get-admin-jwt.sh"
     log_info "Admin token acquired (valid for 1 hour)"
 }
 


### PR DESCRIPTION
## Summary

Fixes six distinct bugs in the local `make e2e` release-gate harness, found while validating v0.5.2 against a full local end-to-end run (two Kind clusters, Helm-deployed Lagoon, Pulumi local-file backend).

- `e2e-build` now installs the locally-built provider plugin's directory onto `PATH` so Pulumi's ambient-plugin discovery finds it, instead of attempting to download an unreleased GitHub release (404).
- `e2e-build` creates the local Pulumi backend directory (`.pulumi-e2e`) before it's needed.
- `e2e` now defaults `PULUMI_CONFIG_PASSPHRASE` to empty for this throwaway local-backend stack, which holds no real secrets and is destroyed every run by `e2e-teardown`.
- `examples/multi-cluster`'s `setup` target hardcoded `pulumi stack select dev`, so `make deploy` (a prerequisite of `e2e-deploy`) always selected/created a `dev` stack instead of reusing the `e2e` stack `e2e-setup` had already created in the same local backend. `e2e-assert` then read empty outputs from the correct `e2e` stack while the actual deploy silently went to `dev`. `setup` now takes an overridable `STACK_NAME` (default `dev`, preserving standalone developer usage), and `e2e-deploy` passes `STACK_NAME=e2e` through.
- `run-pulumi.sh` sourced `get-admin-jwt.sh` via a relative path with one extra `../`, resolving outside the repository entirely instead of to `scripts/get-admin-jwt.sh`.

## Test plan

- [x] `make e2e` run through Phase 1 and Phase 2 successfully with these fixes applied (Harbor, cert-manager, and Lagoon core all deployed and healthy on both clusters; admin JWT correctly acquired)
- [x] Confirmed via full process-tree inspection that `pulumi up` correctly operates against the `e2e` stack throughout (previously it silently diverged to `dev`)
- [x] `e2e-assert`'s `test-api` step surfaced a separate, pre-existing provider bug unrelated to this harness (tracked as #265) — not something these harness fixes are meant to address