### PR TITLE
fix(config): share client instance across LagoonConfig struct copies

### DIFF
--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -34,11 +34,22 @@ type LagoonConfig struct {
 	// Insecure disables SSL certificate verification.
 	Insecure bool `pulumi:"insecure,optional"`
 
-	// clientOnce and cachedClient hold a single shared Client instance.
-	// These are pointer fields so they survive struct copies from infer.GetConfig.
-	// They are initialized by Configure and nil until then.
-	clientOnce   *sync.Once
-	cachedClient *client.Client
+	// clientHolder holds the single shared Client instance for this provider
+	// instance. It is a pointer to a holder struct (not the sync.Once/client
+	// fields directly) so that every copy of LagoonConfig produced by
+	// infer.GetConfig shares the same underlying Once and client slot; a
+	// *sync.Once field alone shares the Once but each copy would still have
+	// its own independent *client.Client field, so only the copy that wins
+	// the Once race would ever see a non-nil client. It is initialized by
+	// Configure and nil until then.
+	clientHolder *clientHolder
+}
+
+// clientHolder is the shared, once-initialized Client instance referenced by
+// all copies of a given LagoonConfig.
+type clientHolder struct {
+	once   sync.Once
+	client *client.Client
 }
 
 // Annotate provides descriptions and defaults for config fields.
@@ -113,7 +124,7 @@ func (c *LagoonConfig) Configure(ctx context.Context) error {
 		c.JWTSecret = ""
 	}
 
-	c.clientOnce = &sync.Once{}
+	c.clientHolder = &clientHolder{}
 
 	return nil
 }
@@ -121,13 +132,17 @@ func (c *LagoonConfig) Configure(ctx context.Context) error {
 // NewClient returns the shared Lagoon API client for this config.
 // The client is created once per provider configure call and reused for all
 // subsequent resource operations, preserving API-version detection cache
-// and token refresh state across operations.
+// and token refresh state across operations. All copies of LagoonConfig
+// produced by infer.GetConfig after Configure share the same clientHolder
+// pointer, so concurrent resource operations correctly observe the one
+// cached client instead of racing to populate independent copies of it.
 func (c *LagoonConfig) NewClient() *client.Client {
-	if c.clientOnce != nil {
-		c.clientOnce.Do(func() {
-			c.cachedClient = c.newClientUncached()
+	if c.clientHolder != nil {
+		h := c.clientHolder
+		h.once.Do(func() {
+			h.client = c.newClientUncached()
 		})
-		return c.cachedClient
+		return h.client
 	}
 	return c.newClientUncached()
 }

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/tag1consulting/pulumi-lagoon/provider/pkg/client"
 )
 
 // requireUnsetEnv removes the named environment variables for the duration
@@ -513,8 +515,8 @@ func TestNewClient_ReusesClient(t *testing.T) {
 	}
 }
 
-func TestNewClient_NilOnce_CreatesNewClient(t *testing.T) {
-	// Without Configure (no clientOnce), NewClient still works — it just
+func TestNewClient_NilHolder_CreatesNewClient(t *testing.T) {
+	// Without Configure (no clientHolder), NewClient still works — it just
 	// creates a fresh client each time rather than reusing one.
 	cfg := &LagoonConfig{APIUrl: "https://api.example.com/graphql", Token: "tok"}
 	c1 := cfg.NewClient()
@@ -524,7 +526,53 @@ func TestNewClient_NilOnce_CreatesNewClient(t *testing.T) {
 	}
 	// Not the same pointer — no caching without Configure
 	if c1 == c2 {
-		t.Error("expected distinct clients when clientOnce is nil")
+		t.Error("expected distinct clients when clientHolder is nil")
+	}
+}
+
+// TestNewClient_ConcurrentStructCopies_ShareSameClient reproduces the scenario
+// that crashes DeployTarget.Create (and any other resource) under concurrent
+// Pulumi resource operations: infer.GetConfig returns independent value
+// copies of LagoonConfig for each operation. Regression test for the bug
+// where cachedClient was a plain *client.Client field — shared clientOnce
+// meant sync.Once.Do ran exactly once total, but only the copy that won the
+// race ever had its cachedClient field populated; every other copy's
+// NewClient() returned nil, and callers dereferencing that nil *Client
+// panicked. See GitHub issue #265.
+func TestNewClient_ConcurrentStructCopies_ShareSameClient(t *testing.T) {
+	for _, k := range []string{"LAGOON_TOKEN", "LAGOON_JWT_SECRET", "LAGOON_API_URL", "LAGOON_JWT_AUDIENCE", "LAGOON_INSECURE"} {
+		t.Setenv(k, "")
+	}
+	t.Setenv("LAGOON_TOKEN", "test-token")
+	cfg := &LagoonConfig{APIUrl: "https://api.example.com/graphql"}
+	if err := cfg.Configure(context.TODO()); err != nil {
+		t.Fatalf("Configure failed: %v", err)
+	}
+
+	const goroutines = 20
+	clients := make([]*client.Client, goroutines)
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// infer.GetConfig returns a value copy of the config struct on
+			// every call; simulate that here by copying cfg by value before
+			// calling NewClient, exactly as concurrent resource Create/Update
+			// calls would each observe their own copy.
+			copyOfCfg := *cfg
+			clients[i] = copyOfCfg.NewClient()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, c := range clients {
+		if c == nil {
+			t.Fatalf("goroutine %d got a nil client", i)
+		}
+		if c != clients[0] {
+			t.Errorf("goroutine %d got a different client instance than goroutine 0; expected all struct copies to share the same cached client", i)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #265: a nil-pointer panic in `DeployTarget.Create` (and any resource calling `NewClient()`) under the Pulumi engine's default parallelism.

`LagoonConfig` cached its Lagoon API client via a `*sync.Once` field plus a plain `*client.Client` field, with a comment claiming both were "pointer fields so they survive struct copies from `infer.GetConfig`." That's true for `*sync.Once` (all copies share the same underlying `Once`), but not for `*client.Client` — it's a plain field, so each value copy of `LagoonConfig` produced by `infer.GetConfig` has its own independent, initially-nil client slot. `sync.Once.Do` runs its closure exactly once for the shared `Once`, populating only the field on whichever copy's goroutine won the race. Every other copy's `NewClient()` returned its own never-populated nil field, and the next call into that nil `*Client` (e.g. `Client.Execute` → `refreshTokenIfNeeded`) panicked with a nil-pointer dereference.

This surfaced during v0.5.2 e2e validation: creating two `DeployTarget`s concurrently (the `examples/multi-cluster` example) reliably crashed the provider plugin mid-`pulumi up`, leaving stack outputs empty.

## Fix

Replace the two separate fields with a single `*clientHolder` pointer whose `once`/`client` fields are read through the same shared struct regardless of which `LagoonConfig` copy calls `NewClient()`.

## Test plan

- [x] New regression test (`TestNewClient_ConcurrentStructCopies_ShareSameClient`) calls `NewClient()` from 20 goroutines on independent value copies of the same configured `LagoonConfig` — mirrors `infer.GetConfig`'s actual copy semantics — and asserts every copy observes the same non-nil client instance
- [x] Verified this test fails against the prior implementation (`goroutine 0 got a nil client`) and passes with the fix, both confirmed under `go test -race`
- [x] Full provider suite (729 tests, 4 packages) passes under `-race`
- [x] Validated against a live two-cluster e2e deploy with concurrent `DeployTarget` creation (the exact reproduction case): zero panics across multiple clean runs, stack outputs (`prod_deploy_target_id`, `nonprod_deploy_target_id`, `example_project_id`) populate correctly