### PR TITLE
fix(config): match LagoonConfig.Diff's type parameters to the framework's actual dispatch

### DIFF
--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -172,7 +172,25 @@ func (c *LagoonConfig) newClientUncached() *client.Client {
 // how the provider authenticates or connects, not which resources it can manage.
 // Returning Update (never UpdateReplace) prevents the cascading replace of every
 // resource associated with this provider instance.
-func (c *LagoonConfig) Diff(_ context.Context, req infer.DiffRequest[LagoonConfig, LagoonConfig]) (infer.DiffResponse, error) {
+//
+// The type parameters are *LagoonConfig, not LagoonConfig: infer.Config is
+// called with a pointer (infer.Config(&LagoonConfig{})), which Go's generics
+// resolve to T = *LagoonConfig. The framework's internal dispatch then checks
+// whether *LagoonConfig implements CustomDiff[*LagoonConfig, *LagoonConfig],
+// not CustomDiff[LagoonConfig, LagoonConfig]. A value-typed signature here
+// silently fails that check and falls through to infer's default diffing,
+// which treats every changed field (including the JWT-derived token, which
+// changes on every Configure call by design) as forcing a full provider
+// replace. See pulumi-lagoon-provider#267.
+func (c *LagoonConfig) Diff(_ context.Context, req infer.DiffRequest[*LagoonConfig, *LagoonConfig]) (infer.DiffResponse, error) {
+	inputs, state := req.Inputs, req.State
+	if inputs == nil {
+		inputs = &LagoonConfig{}
+	}
+	if state == nil {
+		state = &LagoonConfig{}
+	}
+
 	diff := map[string]p.PropertyDiff{}
 	normalizeAudience := func(v string) string {
 		v = strings.TrimSpace(v)
@@ -181,26 +199,26 @@ func (c *LagoonConfig) Diff(_ context.Context, req infer.DiffRequest[LagoonConfi
 		}
 		return v
 	}
-	if strings.TrimSpace(req.Inputs.APIUrl) != strings.TrimSpace(req.State.APIUrl) {
+	if strings.TrimSpace(inputs.APIUrl) != strings.TrimSpace(state.APIUrl) {
 		diff["apiUrl"] = p.PropertyDiff{Kind: p.Update}
 	}
 	// Only diff `token` when it is the explicit credential on both sides.
 	// When jwtSecret is present, Configure derives a fresh token each time;
 	// diffing that derived value produces noise because JWTs change every run.
-	inputSecret := strings.TrimSpace(req.Inputs.JWTSecret)
-	stateSecret := strings.TrimSpace(req.State.JWTSecret)
+	inputSecret := strings.TrimSpace(inputs.JWTSecret)
+	stateSecret := strings.TrimSpace(state.JWTSecret)
 	if inputSecret == "" && stateSecret == "" {
-		if strings.TrimSpace(req.Inputs.Token) != strings.TrimSpace(req.State.Token) {
+		if strings.TrimSpace(inputs.Token) != strings.TrimSpace(state.Token) {
 			diff["token"] = p.PropertyDiff{Kind: p.Update}
 		}
 	}
 	if inputSecret != stateSecret {
 		diff["jwtSecret"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if normalizeAudience(req.Inputs.JWTAudience) != normalizeAudience(req.State.JWTAudience) {
+	if normalizeAudience(inputs.JWTAudience) != normalizeAudience(state.JWTAudience) {
 		diff["jwtAudience"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.Inputs.Insecure != req.State.Insecure {
+	if inputs.Insecure != state.Insecure {
 		diff["insecure"] = p.PropertyDiff{Kind: p.Update}
 	}
 	return p.DiffResponse{HasChanges: len(diff) > 0, DetailedDiff: diff}, nil

--- a/provider/pkg/config/config_test.go
+++ b/provider/pkg/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/tag1consulting/pulumi-lagoon/provider/pkg/client"
 )
 
@@ -405,9 +406,9 @@ func TestConfigure_JWTSecretGeneratesToken(t *testing.T) {
 
 func TestDiff_NoChanges(t *testing.T) {
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{APIUrl: "https://api.test/graphql", Token: "tok", JWTAudience: "api.dev"},
-		State:  LagoonConfig{APIUrl: "https://api.test/graphql", Token: "tok", JWTAudience: "api.dev"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{APIUrl: "https://api.test/graphql", Token: "tok", JWTAudience: "api.dev"},
+		State:  &LagoonConfig{APIUrl: "https://api.test/graphql", Token: "tok", JWTAudience: "api.dev"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -419,9 +420,9 @@ func TestDiff_NoChanges(t *testing.T) {
 
 func TestDiff_WhitespaceDifferencesIgnored(t *testing.T) {
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{Token: "my-token\n", JWTSecret: " secret "},
-		State:  LagoonConfig{Token: "my-token", JWTSecret: "secret"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{Token: "my-token\n", JWTSecret: " secret "},
+		State:  &LagoonConfig{Token: "my-token", JWTSecret: "secret"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -433,9 +434,9 @@ func TestDiff_WhitespaceDifferencesIgnored(t *testing.T) {
 
 func TestDiff_NeverReplace(t *testing.T) {
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{APIUrl: "https://new-api.test/graphql", Token: "new-tok", JWTSecret: "new-secret", JWTAudience: "api.prod", Insecure: true},
-		State:  LagoonConfig{APIUrl: "https://old-api.test/graphql", Token: "old-tok", JWTSecret: "old-secret", JWTAudience: "api.dev", Insecure: false},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{APIUrl: "https://new-api.test/graphql", Token: "new-tok", JWTSecret: "new-secret", JWTAudience: "api.prod", Insecure: true},
+		State:  &LagoonConfig{APIUrl: "https://old-api.test/graphql", Token: "old-tok", JWTSecret: "old-secret", JWTAudience: "api.dev", Insecure: false},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -467,9 +468,9 @@ func TestDiff_NeverReplace(t *testing.T) {
 
 func TestDiff_AudienceDefaultEquivalence(t *testing.T) {
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{JWTAudience: ""},
-		State:  LagoonConfig{JWTAudience: "api.dev"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{JWTAudience: ""},
+		State:  &LagoonConfig{JWTAudience: "api.dev"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -481,9 +482,9 @@ func TestDiff_AudienceDefaultEquivalence(t *testing.T) {
 
 func TestDiff_PartialChange(t *testing.T) {
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{APIUrl: "https://api.test/graphql", Token: "new-tok"},
-		State:  LagoonConfig{APIUrl: "https://api.test/graphql", Token: "old-tok"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{APIUrl: "https://api.test/graphql", Token: "new-tok"},
+		State:  &LagoonConfig{APIUrl: "https://api.test/graphql", Token: "old-tok"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -580,9 +581,9 @@ func TestDiff_JWTSecret_TokenNotDiffed(t *testing.T) {
 	// When jwtSecret is the auth source, the derived token changes every run.
 	// Diff must not report a token change to avoid spurious provider updates.
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{JWTSecret: "my-secret", Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.new"},
-		State:  LagoonConfig{JWTSecret: "my-secret", Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.old"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{JWTSecret: "my-secret", Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.new"},
+		State:  &LagoonConfig{JWTSecret: "my-secret", Token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.old"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -598,9 +599,9 @@ func TestDiff_JWTSecret_TokenNotDiffed(t *testing.T) {
 func TestDiff_JWTSecretChanged_Detected(t *testing.T) {
 	// Changing jwtSecret itself must still be detected.
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{JWTSecret: "new-secret"},
-		State:  LagoonConfig{JWTSecret: "old-secret"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{JWTSecret: "new-secret"},
+		State:  &LagoonConfig{JWTSecret: "old-secret"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -619,9 +620,9 @@ func TestDiff_JWTSecretChanged_Detected(t *testing.T) {
 func TestDiff_ExplicitToken_NoDiffWhenUnchanged(t *testing.T) {
 	// When no jwtSecret, explicit token changes are still detected normally.
 	c := &LagoonConfig{}
-	resp, err := c.Diff(context.Background(), infer.DiffRequest[LagoonConfig, LagoonConfig]{
-		Inputs: LagoonConfig{Token: "tok-v2"},
-		State:  LagoonConfig{Token: "tok-v1"},
+	resp, err := c.Diff(context.Background(), infer.DiffRequest[*LagoonConfig, *LagoonConfig]{
+		Inputs: &LagoonConfig{Token: "tok-v2"},
+		State:  &LagoonConfig{Token: "tok-v1"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -631,5 +632,90 @@ func TestDiff_ExplicitToken_NoDiffWhenUnchanged(t *testing.T) {
 	}
 	if _, ok := resp.DetailedDiff["token"]; !ok {
 		t.Error("expected 'token' in DetailedDiff for explicit token change")
+	}
+}
+
+// ==================== Diff dispatch through the real framework (issue #267) ====================
+
+// dummyArgs/dummyState/dummyResource exist only so infer.NewProviderBuilder has
+// at least one resource to validate against (infer.Config alone is not enough
+// to build a provider). They are not exercised by the assertions below.
+type dummyArgs struct{}
+type dummyState struct{ dummyArgs }
+
+type dummyResource struct{}
+
+func (dummyResource) Create(_ context.Context, req infer.CreateRequest[dummyArgs]) (infer.CreateResponse[dummyState], error) {
+	return infer.CreateResponse[dummyState]{ID: "dummy", Output: dummyState{req.Inputs}}, nil
+}
+
+// TestDiffConfig_DispatchesToCustomDiff is a regression test for issue #267: the
+// provider is wired exactly as production does it (infer.Config(&LagoonConfig{})
+// registers the pointer type, not the value type), and the resulting DiffConfig
+// RPC entry point is called directly - the same path the Pulumi engine calls on
+// every refresh/preview/up. Before the fix, LagoonConfig.Diff was declared with
+// infer.DiffRequest[LagoonConfig, LagoonConfig] (value type parameters), which
+// does not satisfy the CustomDiff[*LagoonConfig, *LagoonConfig] interface the
+// framework actually checks for when the config is registered as a pointer.
+// That mismatch silently fell through to infer's default diffing, which treats
+// any changed field (including the JWT-derived token, expected to change every
+// run) as forcing a full provider replace. Calling c.Diff(...) directly, as the
+// other tests in this file do, cannot catch this: it bypasses the framework's
+// interface-satisfaction check entirely and always succeeds. Only a real
+// DiffConfig RPC call through a built provider exercises the actual bug.
+func TestDiffConfig_DispatchesToCustomDiff(t *testing.T) {
+	// Without the fix, DiffConfig falls through to infer's default diffing
+	// path, which calls GetSchema and needs provider.RunInfo from the
+	// context - context this minimal test harness doesn't provide, so the
+	// fallback path panics instead of just returning a wrong-but-clean
+	// result. Recover so a regression here reports as a normal test
+	// failure rather than crashing the whole test binary.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("DiffConfig panicked: %v (this happens when LagoonConfig.Diff is not dispatched by the "+
+				"framework and infer's default diffing fallback runs instead - see issue #267)", r)
+		}
+	}()
+
+	prov, err := infer.NewProviderBuilder().
+		WithResources(infer.Resource(&dummyResource{})).
+		WithConfig(infer.Config(&LagoonConfig{})).
+		Build()
+	if err != nil {
+		t.Fatalf("failed to build provider: %v", err)
+	}
+	if prov.DiffConfig == nil {
+		t.Fatal("provider.DiffConfig is nil; infer.Config did not wire up DiffConfig")
+	}
+
+	sameSecret := property.New("same-secret")
+	req := p.DiffRequest{
+		Urn: "urn:pulumi:test::test::pulumi:providers:lagoon::lagoon-provider",
+		State: property.NewMap(map[string]property.Value{
+			"apiUrl":    property.New("https://api.test/graphql"),
+			"jwtSecret": sameSecret,
+			"token":     property.New("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.old"),
+		}),
+		Inputs: property.NewMap(map[string]property.Value{
+			"apiUrl":    property.New("https://api.test/graphql"),
+			"jwtSecret": sameSecret,
+			"token":     property.New("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.new"),
+		}),
+	}
+
+	resp, err := prov.DiffConfig(context.Background(), req)
+	if err != nil {
+		t.Fatalf("DiffConfig returned an error: %v", err)
+	}
+	for field, d := range resp.DetailedDiff {
+		if d.Kind == p.UpdateReplace || d.Kind == p.AddReplace || d.Kind == p.DeleteReplace {
+			t.Errorf("DiffConfig marked field %q as %v for a token-only change with identical jwtSecret on "+
+				"both sides; this means LagoonConfig.Diff was not dispatched by the framework and infer's "+
+				"default force-replace-on-any-change fallback ran instead (issue #267). Full DetailedDiff: %+v",
+				field, d.Kind, resp.DetailedDiff)
+		}
+	}
+	if _, ok := resp.DetailedDiff["token"]; ok {
+		t.Errorf("expected 'token' to be absent from DetailedDiff when jwtSecret is unchanged; got: %+v", resp.DetailedDiff)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #267: `pulumi refresh` followed by `preview`/`up` proposed replacing the `lagoon` provider and every resource depending on it, driven by a spurious diff on the JWT-derived token (which changes on every `Configure` call by design and was never meant to be diffed at all).

## Root cause

`infer.Config` is called as `infer.Config(&LagoonConfig{})`, a **pointer**. Go's generics resolve the config's type parameter `T` as `*LagoonConfig`, not `LagoonConfig`. `pulumi-go-provider`'s internal diff dispatch then checks whether `*LagoonConfig` implements `CustomDiff[*LagoonConfig, *LagoonConfig]` before calling into our `Diff` method — but `Diff` was declared as `infer.DiffRequest[LagoonConfig, LagoonConfig]` (value type parameters), which does not satisfy that interface. The check silently failed and fell through to `infer`'s default diffing, which treats any changed field (with no custom `Diff` to say otherwise) as forcing a full provider replace.

Confirmed via runtime reflection: `infer.Config(&LagoonConfig{})` produces a `*config[*LagoonConfig]`, and a direct interface-satisfaction check showed `*LagoonConfig` implements `CustomDiff[LagoonConfig, LagoonConfig]` (the wrong, value-typed interface) but not `CustomDiff[*LagoonConfig, *LagoonConfig]` (the one the framework actually checks for).

## Fix

Change `Diff`'s signature to `infer.DiffRequest[*LagoonConfig, *LagoonConfig]`, matching what `infer.Config`'s pointer registration requires. The body is otherwise unchanged (dereferences `req.Inputs`/`req.State` once at the top, with a nil-safe fallback).

## Test plan

- [x] New regression test (`TestDiffConfig_DispatchesToCustomDiff`) builds a real provider via `infer.NewProviderBuilder` exactly as production does (`WithConfig(infer.Config(&LagoonConfig{}))`) and calls the resulting `DiffConfig` RPC entry point directly — the same path the Pulumi engine calls on every refresh/preview/up. This is the only kind of test that can catch this class of bug: calling `Diff` directly (as the existing tests in this file do) bypasses the framework's interface-satisfaction check entirely and always succeeds regardless of whether the type parameters are correct.
- [x] Verified this test panics/fails against the prior value-typed signature and passes cleanly with the fix
- [x] Full provider test suite (730 tests, 4 packages) passes under `-race`
- [x] Validated against a live two-cluster e2e deploy: a full `up` → `refresh` → `preview` cycle previously showed the provider replace cascading into 6 resources; with the fix, the provider itself shows zero diff during that cycle

## Follow-up

A separate, unrelated issue on `Project.branches`/`pullrequests` drift against a Lagoon API-side placeholder value was found during this validation and filed as #270 — not a regression from this change and not in scope for it.