### PR TITLE
fix(project): treat Lagoon's DeployTargetConfig placeholder as non-drift in Project.Diff

### DIFF
--- a/provider/pkg/resources/project.go
+++ b/provider/pkg/resources/project.go
@@ -213,6 +213,18 @@ func (r *Project) Read(ctx context.Context, req infer.ReadRequest[ProjectArgs, P
 	}, nil
 }
 
+// deployTargetConfigPlaceholder is the literal string the Lagoon API writes into
+// a project's branches/pullrequests columns as soon as any DeployTargetConfig is
+// attached to that project (see uselagoon/lagoon
+// services/api/src/resources/deploytargetconfig/sql.ts,
+// updateProjectBranchPullrequestRegex, invoked from the addDeployTargetConfig
+// resolver). From that point on, routing is controlled per-deploy-target-config
+// and the project-level fields are cosmetic; the API always returns this exact
+// same string for both fields regardless of what was last configured, so a
+// refresh followed by a preview would otherwise show a permanent, unresolvable
+// diff against the user's desired regex. See issue #270.
+const deployTargetConfigPlaceholder = "This project is configured with DeployTargets"
+
 // Diff computes the diff between old and new project state.
 func (r *Project) Diff(ctx context.Context, req infer.DiffRequest[ProjectArgs, ProjectState]) (infer.DiffResponse, error) {
 	diff := map[string]p.PropertyDiff{}
@@ -235,10 +247,16 @@ func (r *Project) Diff(ctx context.Context, req infer.DiffRequest[ProjectArgs, P
 	if req.Inputs.ProductionEnvironment != nil && ptrDiffers(req.Inputs.ProductionEnvironment, req.State.ProductionEnvironment) {
 		diff["productionEnvironment"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.Inputs.Branches != nil && ptrDiffers(req.Inputs.Branches, req.State.Branches) {
+	// The state's placeholder is not real drift: the API always overwrites
+	// branches/pullrequests with this exact string once a DeployTargetConfig
+	// exists, no matter what regex was last applied, so comparing it against the
+	// user's desired input would flag an update on every single preview/up.
+	stateBranchesIsPlaceholder := req.State.Branches != nil && *req.State.Branches == deployTargetConfigPlaceholder
+	if req.Inputs.Branches != nil && !stateBranchesIsPlaceholder && ptrDiffers(req.Inputs.Branches, req.State.Branches) {
 		diff["branches"] = p.PropertyDiff{Kind: p.Update}
 	}
-	if req.Inputs.Pullrequests != nil && ptrDiffers(req.Inputs.Pullrequests, req.State.Pullrequests) {
+	statePullrequestsIsPlaceholder := req.State.Pullrequests != nil && *req.State.Pullrequests == deployTargetConfigPlaceholder
+	if req.Inputs.Pullrequests != nil && !statePullrequestsIsPlaceholder && ptrDiffers(req.Inputs.Pullrequests, req.State.Pullrequests) {
 		diff["pullrequests"] = p.PropertyDiff{Kind: p.Update}
 	}
 	if req.Inputs.OpenshiftProjectPattern != nil && ptrDiffers(req.Inputs.OpenshiftProjectPattern, req.State.OpenshiftProjectPattern) {

--- a/provider/pkg/resources/project_crud_test.go
+++ b/provider/pkg/resources/project_crud_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	p "github.com/pulumi/pulumi-go-provider"
 	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	"github.com/tag1consulting/pulumi-lagoon/provider/pkg/client"
 )
 
@@ -423,5 +425,154 @@ func TestProjectCreate_OptionalFields(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Create with optional fields failed: %v", err)
+	}
+}
+
+// ==================== Diff: DeployTargetConfig placeholder (issue #270) ====================
+
+// TestProjectDiff_DeployTargetPlaceholder_NoDiff reproduces the scenario from
+// issue #270: once a DeployTargetConfig is attached to a project, the Lagoon
+// API overwrites the project's branches/pullrequests columns with a fixed
+// placeholder string. A refresh then picks up that placeholder as state, and
+// the next preview must not diff it against the user's actual desired regex.
+func TestProjectDiff_DeployTargetPlaceholder_NoDiff(t *testing.T) {
+	desiredBranches := "^(main|develop|feature/.*)$"
+	desiredPRs := ".*"
+	placeholder := deployTargetConfigPlaceholder
+
+	r := &Project{}
+	resp, err := r.Diff(context.Background(), infer.DiffRequest[ProjectArgs, ProjectState]{
+		Inputs: ProjectArgs{
+			Name:         "myproject",
+			GitURL:       "git@example.com:repo.git",
+			Branches:     &desiredBranches,
+			Pullrequests: &desiredPRs,
+		},
+		State: ProjectState{
+			ProjectArgs: ProjectArgs{
+				Name:         "myproject",
+				GitURL:       "git@example.com:repo.git",
+				Branches:     &placeholder,
+				Pullrequests: &placeholder,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if resp.HasChanges {
+		t.Errorf("expected no changes when state holds the DeployTargetConfig placeholder; got diff: %+v", resp.DetailedDiff)
+	}
+	if _, ok := resp.DetailedDiff["branches"]; ok {
+		t.Error("expected 'branches' to be absent from DetailedDiff when state is the DeployTargetConfig placeholder")
+	}
+	if _, ok := resp.DetailedDiff["pullrequests"]; ok {
+		t.Error("expected 'pullrequests' to be absent from DetailedDiff when state is the DeployTargetConfig placeholder")
+	}
+}
+
+// TestProjectDiff_RealDrift_StillDetected ensures the placeholder special-case
+// doesn't mask genuine drift: when the state holds anything other than the
+// exact placeholder string, a real difference must still be reported.
+func TestProjectDiff_RealDrift_StillDetected(t *testing.T) {
+	desired := "^(main|develop)$"
+	stateVal := "^(main)$"
+
+	r := &Project{}
+	resp, err := r.Diff(context.Background(), infer.DiffRequest[ProjectArgs, ProjectState]{
+		Inputs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", Branches: &desired},
+		State: ProjectState{
+			ProjectArgs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", Branches: &stateVal},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Error("expected changes when branches genuinely differ and state is not the DeployTargetConfig placeholder")
+	}
+	if _, ok := resp.DetailedDiff["branches"]; !ok {
+		t.Error("expected 'branches' in DetailedDiff for genuine drift")
+	}
+}
+
+// TestProjectDiff_PlaceholderLookalike_StillDetected guards against a
+// too-broad match: a value that merely resembles the placeholder (e.g. a
+// user's own regex happens to equal it, or the API string changes slightly in
+// a future Lagoon version) must not be silently swallowed. Only an exact match
+// of the documented placeholder is suppressed.
+func TestProjectDiff_PlaceholderLookalike_StillDetected(t *testing.T) {
+	desired := "^(main)$"
+	lookalike := "This project is configured with DeployTarget" // missing trailing "s"
+
+	r := &Project{}
+	resp, err := r.Diff(context.Background(), infer.DiffRequest[ProjectArgs, ProjectState]{
+		Inputs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", Branches: &desired},
+		State: ProjectState{
+			ProjectArgs: ProjectArgs{Name: "myproject", GitURL: "git@example.com:repo.git", Branches: &lookalike},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	if !resp.HasChanges {
+		t.Error("expected changes when state is merely similar to, but not exactly, the DeployTargetConfig placeholder")
+	}
+}
+
+// TestDiffProject_DispatchesToCustomDiff is a regression test for issue #270,
+// following the same framework-dispatch pattern established for issue #267
+// (see config_test.go's TestDiffConfig_DispatchesToCustomDiff): it builds the
+// provider exactly as production does (infer.Resource(&resources.Project{}))
+// and calls the resulting provider's real Diff RPC entrypoint with property.Map
+// state/inputs, rather than calling (*Project).Diff directly. This exercises
+// the actual interface-dispatch path the Pulumi engine uses on every
+// refresh/preview/up, not just the Go method in isolation.
+func TestDiffProject_DispatchesToCustomDiff(t *testing.T) {
+	prov, err := infer.NewProviderBuilder().
+		WithResources(infer.Resource(&Project{})).
+		Build()
+	if err != nil {
+		t.Fatalf("failed to build provider: %v", err)
+	}
+	if prov.Diff == nil {
+		t.Fatal("provider.Diff is nil; infer.Resource did not wire up Diff")
+	}
+
+	req := p.DiffRequest{
+		ID:  "1",
+		Urn: "urn:pulumi:test::test::lagoon:lagoon:Project::myproject",
+		State: property.NewMap(map[string]property.Value{
+			"name":           property.New("myproject"),
+			"gitUrl":         property.New("git@example.com:repo.git"),
+			"deploytargetId": property.New(1.0),
+			"branches":       property.New(deployTargetConfigPlaceholder),
+			"pullrequests":   property.New(deployTargetConfigPlaceholder),
+			"lagoonId":       property.New(1.0),
+			"publicKey":      property.New(""),
+			"created":        property.New(""),
+		}),
+		Inputs: property.NewMap(map[string]property.Value{
+			"name":           property.New("myproject"),
+			"gitUrl":         property.New("git@example.com:repo.git"),
+			"deploytargetId": property.New(1.0),
+			"branches":       property.New("^(main|develop|feature/.*)$"),
+			"pullrequests":   property.New(".*"),
+		}),
+	}
+
+	resp, err := prov.Diff(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Diff returned an error: %v", err)
+	}
+	for field, d := range resp.DetailedDiff {
+		if d.Kind == p.UpdateReplace || d.Kind == p.AddReplace || d.Kind == p.DeleteReplace {
+			t.Errorf("Diff marked field %q as %v for a DeployTargetConfig-placeholder-only difference; "+
+				"expected no diff at all. Full DetailedDiff: %+v", field, d.Kind, resp.DetailedDiff)
+		}
+	}
+	if resp.HasChanges {
+		t.Errorf("expected no changes through the real dispatch path when state holds the DeployTargetConfig "+
+			"placeholder for branches/pullrequests; got: %+v", resp.DetailedDiff)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #270: after a project has one or more `DeployTargetConfig`s attached, `pulumi refresh` followed by `preview` showed a permanent, unresolvable diff on `Project.branches`/`pullrequests`, cascading into a replace of every `DeployTargetConfig` whose `projectId` depends on the `Project` resource's output.

## Root cause

Confirmed directly against the Lagoon API's own source, not just inferred from behavior: `uselagoon/lagoon` `services/api/src/resources/deploytargetconfig/sql.ts`, function `updateProjectBranchPullrequestRegex`, called unconditionally from the `addDeployTargetConfig` resolver (`services/api/src/resources/deploytargetconfig/resolvers.ts`):

```ts
updateProjectBranchPullrequestRegex: (id: number) =>
  knex('project')
    .update('branches', 'This project is configured with DeployTargets')
    .update('pullrequests', 'This project is configured with DeployTargets')
    .where('id', '=', id)
    .toString(),
```

As soon as any `DeployTargetConfig` is attached to a project, the API overwrites both `branches` and `pullrequests` in the `project` table with this exact literal string, regardless of what regex was last configured. The resolver's own comment confirms the intent: "patch the project with the message to inform a user that their project is now using deploytarget configurations... this is an alpha feature with no UI support." From that point on, routing is controlled per-`DeployTargetConfig` and the project-level fields are purely cosmetic/informational.

A `refresh` picks up this placeholder as the resource's current state (since it re-reads from the live API), and the next `preview`/`up` then diffs it against the user's real desired regex, forcing an update on `Project` on every single run. Because `DeployTargetConfig.projectId` is typically wired to `project.lagoonId` (an output of `Project`), that pending `Project` update makes the output "unknown" mid-preview, and `DeployTargetConfig.Diff` already treats any `projectId` mismatch as force-replace — cascading into a replace of every `DeployTargetConfig`.

## Fix

`Project.Diff` now special-cases an exact match against this documented placeholder value, but only on the **state** side. It does not touch the desired-input side at all, so a user could never accidentally configure the placeholder itself as a real value and have it silently accepted. Any state value other than the exact literal (including a near-miss, in case a future Lagoon version tweaks the string) still diffs normally against the desired input, so genuine drift on `branches`/`pullrequests` is not masked.

This follows the same pattern already established in `LagoonConfig.Diff` for the `jwtAudience`/`api.dev` equivalence.

## Test plan

- [x] `TestProjectDiff_DeployTargetPlaceholder_NoDiff`: reproduces the exact issue #270 scenario (state holds the placeholder, desired input holds a real regex) and asserts no diff
- [x] `TestProjectDiff_RealDrift_StillDetected`: confirms genuine drift between two non-placeholder values is still caught
- [x] `TestProjectDiff_PlaceholderLookalike_StillDetected`: confirms a value that merely resembles the placeholder (not an exact match) is not silently swallowed
- [x] `TestDiffProject_DispatchesToCustomDiff`: builds the provider via `infer.NewProviderBuilder` exactly as production does and calls the real `Diff` RPC entrypoint, following the framework-dispatch pattern established in #271/#267 (calling `(*Project).Diff` directly cannot catch dispatch-level regressions)
- [x] Full provider test suite passes: `go test ./... -count=1` (734 tests, 5 packages)
- [x] `go vet ./...` clean