### PR TITLE
fix(e2e): resolve venv's python3 in get-admin-jwt.sh

### DIFF
--- a/scripts/get-admin-jwt.sh
+++ b/scripts/get-admin-jwt.sh
@@ -15,7 +15,9 @@
 #   - kubectl configured with the prod context (KUBE_CONTEXT, defaults to kind-lagoon-prod)
 #   - The lagoon-core namespace (LAGOON_NAMESPACE, defaults to lagoon-core)
 #   - CORE_SECRETS secret (defaults to prod-core-lagoon-core-secrets)
-#   - Python 3 with PyJWT available (provided by the example venv)
+#   - PyJWT installed into examples/multi-cluster/venv (via `make e2e-setup` or
+#     `pip install -r examples/multi-cluster/requirements.txt`); this script
+#     resolves that venv's python3 directly rather than relying on $PATH
 #
 # Environment variables (all optional, sensible defaults for multi-cluster prod):
 #   KUBE_CONTEXT    - kubectl context (default: kind-lagoon-prod)
@@ -26,6 +28,23 @@
 #   LAGOON_API_URL  - if set, skip overriding; if unset, set to http://localhost:7080/graphql
 
 set -e
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REPO_ROOT="$(cd "$_SCRIPT_DIR/.." && pwd)"
+
+# Resolve the venv's Python directly rather than relying on `python3` from
+# $PATH: e2e-assert's caller cd's into examples/multi-cluster before sourcing
+# this script, but a bare `python3` still resolves through the invoking
+# shell's PATH, not the venv, so PyJWT (installed only into the venv by
+# `make e2e-setup`) was silently unavailable. Check the same candidate
+# locations run-pulumi.sh already searches for the venv.
+_PYTHON="python3"
+for _venv in "./venv" "$_REPO_ROOT/examples/multi-cluster/venv" "$_REPO_ROOT/venv"; do
+    if [ -x "$_venv/bin/python3" ]; then
+        _PYTHON="$_venv/bin/python3"
+        break
+    fi
+done
 
 _CONTEXT="${KUBE_CONTEXT:-kind-lagoon-prod}"
 _NAMESPACE="${LAGOON_NAMESPACE:-lagoon-core}"
@@ -49,8 +68,8 @@ fi
 # Generate the HS256 token via Python; secret is passed via an env var to avoid
 # shell-escaping issues, disk writes, and the SC2259 pipe-vs-heredoc conflict.
 # (A heredoc overrides piped stdin, so env var is the correct approach here.)
-# PyJWT must be available in the active venv.
-_token=$(_JWTSECRET="$_jwt_secret" python3 - <<EOF
+# PyJWT must be available in the interpreter resolved above.
+_token=$(_JWTSECRET="$_jwt_secret" "$_PYTHON" - <<EOF
 import jwt, time, os
 secret = os.environ['_JWTSECRET']
 now = int(time.time())


### PR DESCRIPTION
## Summary

Fixes Group 3 ("Live API readback") of the local `make e2e` release-gate harness, which was failing with `ModuleNotFoundError: No module named 'jwt'`.

## Root cause

`scripts/get-admin-jwt.sh` (used by `scripts/e2e-assertions.sh`'s Group 3 to mint an admin JWT for a live GraphQL readback check) called bare `python3` to sign the token. Bare `python3` resolves through the invoking shell's `PATH`, not the `examples/multi-cluster/venv` that `make e2e-setup` creates and installs `PyJWT` into. When the shell's active `python3` differs from that venv (confirmed: the venv's `python3` has `PyJWT==2.13.0` installed and working; the system `python3` on this machine's `PATH` does not have it at all), the script fails.

This was discovered while validating PR #274 and PR #275 end-to-end: Groups 1 and 2 (including the specific assertion that validates #274's fix, "no pending diff after refresh") passed cleanly on merged `main`, but Group 3 aborted on this unrelated dependency-resolution bug.

## Fix

`get-admin-jwt.sh` now resolves the venv's `python3` directly, using the same candidate-location search `scripts/run-pulumi.sh` already uses to activate the venv (`./venv`, `examples/multi-cluster/venv` relative to repo root, `$REPO_ROOT/venv`), falling back to bare `python3` only if none of those exist.

## Verification

- Confirmed the venv's `python3` has `PyJWT==2.13.0` importable; the system `python3` on `PATH` does not.
- Manually verified the interpreter-resolution logic from both invocation contexts the script documents: from `examples/multi-cluster/` (the CWD `make e2e-assert` actually uses) and from the repo root (the standalone usage in the script's own header comment). Both resolve to the venv's `python3` and successfully `import jwt`.
- `bash -n scripts/get-admin-jwt.sh`: syntax OK.
- `shellcheck scripts/get-admin-jwt.sh`: no findings.

Not re-run through the full `make e2e` (45-90 minutes) for this PR; the fix is a small, isolated interpreter-resolution change verified directly against the actual failure mode. A full e2e re-run already confirmed Groups 1-2 pass on merged main immediately before this fix was written.
