### PR TITLE
Follow up PR #285: finish Go 1.27 CI rollout, align golangci-lint config and docs

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.26']
+        go-version: ['1.27']
 
     steps:
       - uses: actions/checkout@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  go: "1.26"
+  go: "1.27"
 
 linters:
   enable:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ The provider is available on PyPI (`pip install pulumi-lagoon`), npm (`@tag1cons
 ## Development Environment
 
 ### Prerequisites
-- Go 1.26+
+- Go 1.27+
 - Pulumi CLI installed
 - Access to a Lagoon instance with API credentials
 - GraphQL API endpoint and authentication token

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions, bug reports, and feedback are welcome. Please follow our [Code of
 
 ## Prerequisites
 
-- Go 1.26+
+- Go 1.27+
 - [Pulumi CLI](https://www.pulumi.com/docs/install/) — version must match `.pulumiversion` (currently 3.234.0). SDK generation output varies between CLI versions, so mismatches cause spurious diffs. Install a specific version with: `curl -fsSL https://get.pulumi.com | sh -s -- --version $(cat .pulumiversion)`
 - A running Lagoon instance with API credentials (required for integration tests only; unit tests are self-contained)
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ lagoon get project --project my-project
 
 ### Prerequisites
 
-- Go 1.26+
+- Go 1.27+
 - Pulumi CLI
 - Docker, Kind, kubectl, jq (for local test clusters)
 

--- a/site/contributing.md
+++ b/site/contributing.md
@@ -9,7 +9,7 @@ Contributions, bug reports, and feedback are welcome. Please review the [Code of
 
 ## Prerequisites
 
-- Go 1.26+
+- Go 1.27+
 - [Pulumi CLI](https://www.pulumi.com/docs/install/) — version must match `.pulumiversion`. SDK generation output varies between CLI versions, so mismatches cause spurious diffs in the generated files. Install the pinned version with:
   ```bash
   curl -fsSL https://get.pulumi.com | sh -s -- --version $(cat .pulumiversion)


### PR DESCRIPTION
## Summary
- `test-go.yml`: the `test` job's matrix pin (`go-version: ['1.26']`) was missed by PR #285's Renovate diff — vet/lint/build already run on 1.27, this brings `test` in line so unit tests run under the same toolchain.
- `.golangci.yml`: bumps `run.go` from `"1.26"` to `"1.27"` so golangci-lint's assumed language/stdlib target matches the toolchain it actually runs under.
- `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`, `site/contributing.md`: bump the "Go 1.26+" provider build/contributor prerequisite to "Go 1.27+".

## Deliberately not touched
`site/getting-started.md`'s "Go 1.26+" line is under SDK-consumer runtime requirements, not provider build prerequisites — it's already inconsistent with `sdk/go/lagoon/go.mod`'s declared `go 1.25.0` floor. That's a separate, pre-existing issue unrelated to this CI follow-up, left for its own fix.

## Test plan
- [x] Confirm the `test` job in CI runs under Go 1.27 and passes
- [x] Confirm `lint` still passes with the golangci-lint `run.go: "1.27"` config