### PR TITLE
Enable AI PR review on Dependabot PRs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,6 +11,13 @@ name: AI PR Review
 # trigger a secret-bearing run even if the action invariant ever regressed.
 # Mirror of the gate already used by ai-review-commands.yml for slash commands.
 #
+# Dependabot carve-out: dependabot[bot]'s author_association on this repo is
+# CONTRIBUTOR, not COLLABORATOR, so it needs an explicit OR to pass the gate
+# above. This is safe because Dependabot PRs here are same-repo branches
+# (isCrossRepository: false), not forks, so the fork-secret-leak risk the
+# association gate defends against does not apply. renovate[bot] stays
+# excluded.
+#
 # Note: tag1consulting/ai-pr-review/container-action@main is intentionally a
 # mutable ref. This is a dogfooding/canary repo and we own the action; the
 # mutable-ref supply-chain risk is accepted, with the action invariant above
@@ -28,10 +35,12 @@ jobs:
   review:
     if: |
       !github.event.pull_request.draft &&
-      github.actor != 'dependabot[bot]' &&
       github.actor != 'renovate[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        github.actor == 'dependabot[bot]'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- `ai-review.yml` currently excludes both `dependabot[bot]` and `renovate[bot]` from triggering an AI review.
- This PR removes the Dependabot exclusion so its PRs (e.g. #287) get reviewed, and adds an explicit carve-out in the `author_association` gate since Dependabot's association on this repo is `CONTRIBUTOR`, not `COLLABORATOR`.
- Renovate stays excluded — not part of this request.

## Why it's safe
The `author_association` gate is defense-in-depth against `pull_request_target` exposing secrets to an arbitrary fork actor. Dependabot PRs here are same-repo branches (`isCrossRepository: false`), not forks, so that specific risk doesn't apply to the carve-out.

## Test plan
- [ ] Open/push a Dependabot PR (or re-push #287) and confirm the AI review job now runs and posts a review
- [ ] Confirm a Renovate PR still does *not* trigger AI review