### PR TITLE
Fix Dependabot carve-out: key off PR author, not triggering actor

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,6 +18,13 @@ name: AI PR Review
 # association gate defends against does not apply. renovate[bot] stays
 # excluded.
 #
+# The carve-out keys off pull_request.user.login (the PR's stable original
+# author), not github.actor (whoever triggered this specific event). A
+# Dependabot PR frequently gets updated by someone/something other than
+# Dependabot itself (e.g. clicking "Update branch" creates a merge commit
+# authored by that person), which would flip github.actor away from
+# 'dependabot[bot]' and silently defeat an actor-keyed carve-out.
+#
 # Note: tag1consulting/ai-pr-review/container-action@main is intentionally a
 # mutable ref. This is a dogfooding/canary repo and we own the action; the
 # mutable-ref supply-chain risk is accepted, with the action invariant above
@@ -39,7 +46,7 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'skip-ai-review') &&
       (
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
-        github.actor == 'dependabot[bot]'
+        github.event.pull_request.user.login == 'dependabot[bot]'
       )
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Follow-up to #289, which added a Dependabot carve-out to `ai-review.yml`'s `author_association` gate, keyed on `github.actor == 'dependabot[bot]'`.
- That check only matches when Dependabot itself is the one pushing. On #287, a "Update branch" click created a merge commit authored by a human, so `github.actor` was the human — the carve-out silently didn't fire and the review job was skipped (confirmed via the run logs: `actor: gchaix, triggering_actor: gchaix`).
- Fix: read `github.event.pull_request.user.login` instead — the PR's original, stable author — which stays `dependabot[bot]` regardless of who pushes subsequent commits.

## Test plan
- [ ] Push a new commit to #287 (or click "Update branch" again) and confirm the AI review job now runs (not skipped)
- [ ] Confirm a Renovate PR still does *not* trigger AI review